### PR TITLE
Fix select dropdown icon imports

### DIFF
--- a/src/routes/Category.tsx
+++ b/src/routes/Category.tsx
@@ -6,7 +6,7 @@ import LoadingSkeleton from "@/components/common/LoadingSkeleton";
 import ErrorState from "@/components/common/ErrorState";
 import ThreadItem from "@/components/forum/ThreadItem";
 import EmptyState from "@/components/forum/EmptyState";
-import { SelectArrowIcon } from "@radix-ui/react-select";
+import { ChevronDown } from "lucide-react";
 
 const sortOptions = [
   { value: "new", label: "Neueste" },
@@ -60,7 +60,7 @@ const Category = () => {
                 </option>
               ))}
             </select>
-            <SelectArrowIcon className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/routes/CreatePost.tsx
+++ b/src/routes/CreatePost.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import PageTransition from "@/components/layout/PageTransition";
 import { useForumStore } from "@/store/forumStore";
 import Composer from "@/components/forum/Composer";
-import { SelectArrowIcon } from "@radix-ui/react-select";
+import { ChevronDown } from "lucide-react";
 import type { Category } from "@/lib/api/types";
 import { toast } from "sonner";
 
@@ -63,7 +63,7 @@ const CreatePost = () => {
                   </option>
                 ))}
               </select>
-              <SelectArrowIcon className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
             </div>
           </div>
           <Composer onSubmit={handleSubmit} variant="thread" isSubmitting={submitting} />


### PR DESCRIPTION
## Summary
- replace SelectArrowIcon usage with the lucide-react ChevronDown icon in Category and CreatePost selects to resolve the runtime import error

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f3079ff8832792983e6eeb0a38ed