### PR TITLE
feat: refresh forum layout and stabilize particles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-tabs": "^1.0.4",
         "@radix-ui/react-tooltip": "^1.0.7",
+        "@tsparticles/engine": "^3.0.0",
+        "@tsparticles/react": "^3.0.0",
+        "@tsparticles/slim": "^3.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "framer-motion": "^10.18.0",
@@ -27,10 +30,8 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^9.0.1",
         "react-router-dom": "^6.22.3",
-        "react-tsparticles": "^2.12.2",
         "sonner": "^1.4.41",
         "tailwind-merge": "^2.2.1",
-        "tsparticles": "^2.12.0",
         "zustand": "^4.5.2"
       },
       "devDependencies": {
@@ -2272,6 +2273,470 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tsparticles/basic": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
+      "integrity": "sha512-ijr2dHMx0IQHqhKW3qA8tfwrR2XYbbWYdaJMQuBo2CkwBVIhZ76U+H20Y492j/NXpd1FUnt2aC0l4CEVGVGdeQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1",
+        "@tsparticles/move-base": "3.9.1",
+        "@tsparticles/plugin-hex-color": "3.9.1",
+        "@tsparticles/plugin-hsl-color": "3.9.1",
+        "@tsparticles/plugin-rgb-color": "3.9.1",
+        "@tsparticles/shape-circle": "3.9.1",
+        "@tsparticles/updater-color": "3.9.1",
+        "@tsparticles/updater-opacity": "3.9.1",
+        "@tsparticles/updater-out-modes": "3.9.1",
+        "@tsparticles/updater-size": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/engine": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-3.9.1.tgz",
+      "integrity": "sha512-DpdgAhWMZ3Eh2gyxik8FXS6BKZ8vyea+Eu5BC4epsahqTGY9V3JGGJcXC6lRJx6cPMAx1A0FaQAojPF3v6rkmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "hasInstallScript": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsparticles/interaction-external-attract": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-3.9.1.tgz",
+      "integrity": "sha512-5AJGmhzM9o4AVFV24WH5vSqMBzOXEOzIdGLIr+QJf4fRh9ZK62snsusv/ozKgs2KteRYQx+L7c5V3TqcDy2upg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-bounce": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-3.9.1.tgz",
+      "integrity": "sha512-bv05+h70UIHOTWeTsTI1AeAmX6R3s8nnY74Ea6p6AbQjERzPYIa0XY19nq/hA7+Nrg+EissP5zgoYYeSphr85A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-bubble": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-3.9.1.tgz",
+      "integrity": "sha512-tbd8ox/1GPl+zr+KyHQVV1bW88GE7OM6i4zql801YIlCDrl9wgTDdDFGIy9X7/cwTvTrCePhrfvdkUamXIribQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-connect": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-3.9.1.tgz",
+      "integrity": "sha512-sq8YfUNsIORjXHzzW7/AJQtfi/qDqLnYG2qOSE1WOsog39MD30RzmiOloejOkfNeUdcGUcfsDgpUuL3UhzFUOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-grab": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-3.9.1.tgz",
+      "integrity": "sha512-QwXza+sMMWDaMiFxd8y2tJwUK6c+nNw554+/9+tEZeTTk2fCbB0IJ7p/TH6ZGWDL0vo2muK54Njv2fEey191ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-pause": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-3.9.1.tgz",
+      "integrity": "sha512-Gzv4/FeNir0U/tVM9zQCqV1k+IAgaFjDU3T30M1AeAsNGh/rCITV2wnT7TOGFkbcla27m4Yxa+Fuab8+8pzm+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-push": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-3.9.1.tgz",
+      "integrity": "sha512-GvnWF9Qy4YkZdx+WJL2iy9IcgLvzOIu3K7aLYJFsQPaxT8d9TF8WlpoMlWKnJID6H5q4JqQuMRKRyWH8aAKyQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-remove": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-3.9.1.tgz",
+      "integrity": "sha512-yPThm4UDWejDOWW5Qc8KnnS2EfSo5VFcJUQDWc1+Wcj17xe7vdSoiwwOORM0PmNBzdDpSKQrte/gUnoqaUMwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-repulse": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-3.9.1.tgz",
+      "integrity": "sha512-/LBppXkrMdvLHlEKWC7IykFhzrz+9nebT2fwSSFXK4plEBxDlIwnkDxd3FbVOAbnBvx4+L8+fbrEx+RvC8diAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-external-slow": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-3.9.1.tgz",
+      "integrity": "sha512-1ZYIR/udBwA9MdSCfgADsbDXKSFS0FMWuPWz7bm79g3sUxcYkihn+/hDhc6GXvNNR46V1ocJjrj0u6pAynS1KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-particles-attract": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-3.9.1.tgz",
+      "integrity": "sha512-CYYYowJuGwRLUixQcSU/48PTKM8fCUYThe0hXwQ+yRMLAn053VHzL7NNZzKqEIeEyt5oJoy9KcvubjKWbzMBLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-particles-collisions": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-3.9.1.tgz",
+      "integrity": "sha512-ggGyjW/3v1yxvYW1IF1EMT15M6w31y5zfNNUPkqd/IXRNPYvm0Z0ayhp+FKmz70M5p0UxxPIQHTvAv9Jqnuj8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/interaction-particles-links": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-3.9.1.tgz",
+      "integrity": "sha512-MsLbMjy1vY5M5/hu/oa5OSRZAUz49H3+9EBMTIOThiX+a+vpl3sxc9AqNd9gMsPbM4WJlub8T6VBZdyvzez1Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/move-base": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/move-base/-/move-base-3.9.1.tgz",
+      "integrity": "sha512-X4huBS27d8srpxwOxliWPUt+NtCwY+8q/cx1DvQxyqmTA8VFCGpcHNwtqiN+9JicgzOvSuaORVqUgwlsc7h4pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/move-parallax": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/move-parallax/-/move-parallax-3.9.1.tgz",
+      "integrity": "sha512-whlOR0bVeyh6J/hvxf/QM3DqvNnITMiAQ0kro6saqSDItAVqg4pYxBfEsSOKq7EhjxNvfhhqR+pFMhp06zoCVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-easing-quad": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-3.9.1.tgz",
+      "integrity": "sha512-C2UJOca5MTDXKUTBXj30Kiqr5UyID+xrY/LxicVWWZPczQW2bBxbIbfq9ULvzGDwBTxE2rdvIB8YFKmDYO45qw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hex-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-3.9.1.tgz",
+      "integrity": "sha512-vZgZ12AjUicJvk7AX4K2eAmKEQX/D1VEjEPFhyjbgI7A65eX72M465vVKIgNA6QArLZ1DLs7Z787LOE6GOBWsg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-hsl-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-3.9.1.tgz",
+      "integrity": "sha512-jJd1iGgRwX6eeNjc1zUXiJivaqC5UE+SC2A3/NtHwwoQrkfxGWmRHOsVyLnOBRcCPgBp/FpdDe6DIDjCMO715w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/plugin-rgb-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-3.9.1.tgz",
+      "integrity": "sha512-SBxk7f1KBfXeTnnklbE2Hx4jBgh6I6HOtxb+Os1gTp0oaghZOkWcCD2dP4QbUu7fVNCMOcApPoMNC8RTFcy9wQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/react": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tsparticles/react/-/react-3.0.0.tgz",
+      "integrity": "sha512-hjGEtTT1cwv6BcjL+GcVgH++KYs52bIuQGW3PWv7z3tMa8g0bd6RI/vWSLj7p//NZ3uTjEIeilYIUPBh7Jfq/Q==",
+      "peerDependencies": {
+        "@tsparticles/engine": "^3.0.2",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@tsparticles/shape-circle": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-3.9.1.tgz",
+      "integrity": "sha512-DqZFLjbuhVn99WJ+A9ajz9YON72RtCcvubzq6qfjFmtwAK7frvQeb6iDTp6Ze9FUipluxVZWVRG4vWTxi2B+/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-emoji": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-3.9.1.tgz",
+      "integrity": "sha512-ifvY63usuT+hipgVHb8gelBHSeF6ryPnMxAAEC1RGHhhXfpSRWMtE6ybr+pSsYU52M3G9+TF84v91pSwNrb9ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-image": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-3.9.1.tgz",
+      "integrity": "sha512-fCA5eme8VF3oX8yNVUA0l2SLDKuiZObkijb0z3Ky0qj1HUEVlAuEMhhNDNB9E2iELTrWEix9z7BFMePp2CC7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-line": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-3.9.1.tgz",
+      "integrity": "sha512-wT8NSp0N9HURyV05f371cHKcNTNqr0/cwUu6WhBzbshkYGy1KZUP9CpRIh5FCrBpTev34mEQfOXDycgfG0KiLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-polygon": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-3.9.1.tgz",
+      "integrity": "sha512-dA77PgZdoLwxnliH6XQM/zF0r4jhT01pw5y7XTeTqws++hg4rTLV9255k6R6eUqKq0FPSW1/WBsBIl7q/MmrqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-square": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-3.9.1.tgz",
+      "integrity": "sha512-DKGkDnRyZrAm7T2ipqNezJahSWs6xd9O5LQLe5vjrYm1qGwrFxJiQaAdlb00UNrexz1/SA7bEoIg4XKaFa7qhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/shape-star": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-3.9.1.tgz",
+      "integrity": "sha512-kdMJpi8cdeb6vGrZVSxTG0JIjCwIenggqk0EYeKAwtOGZFBgL7eHhF2F6uu1oq8cJAbXPujEoabnLsz6mW8XaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/slim": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-3.9.1.tgz",
+      "integrity": "sha512-CL5cDmADU7sDjRli0So+hY61VMbdroqbArmR9Av+c1Fisa5ytr6QD7Jv62iwU2S6rvgicEe9OyRmSy5GIefwZw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/matteobruni"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/tsparticles"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://www.buymeacoffee.com/matteobruni"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/basic": "3.9.1",
+        "@tsparticles/engine": "3.9.1",
+        "@tsparticles/interaction-external-attract": "3.9.1",
+        "@tsparticles/interaction-external-bounce": "3.9.1",
+        "@tsparticles/interaction-external-bubble": "3.9.1",
+        "@tsparticles/interaction-external-connect": "3.9.1",
+        "@tsparticles/interaction-external-grab": "3.9.1",
+        "@tsparticles/interaction-external-pause": "3.9.1",
+        "@tsparticles/interaction-external-push": "3.9.1",
+        "@tsparticles/interaction-external-remove": "3.9.1",
+        "@tsparticles/interaction-external-repulse": "3.9.1",
+        "@tsparticles/interaction-external-slow": "3.9.1",
+        "@tsparticles/interaction-particles-attract": "3.9.1",
+        "@tsparticles/interaction-particles-collisions": "3.9.1",
+        "@tsparticles/interaction-particles-links": "3.9.1",
+        "@tsparticles/move-parallax": "3.9.1",
+        "@tsparticles/plugin-easing-quad": "3.9.1",
+        "@tsparticles/shape-emoji": "3.9.1",
+        "@tsparticles/shape-image": "3.9.1",
+        "@tsparticles/shape-line": "3.9.1",
+        "@tsparticles/shape-polygon": "3.9.1",
+        "@tsparticles/shape-square": "3.9.1",
+        "@tsparticles/shape-star": "3.9.1",
+        "@tsparticles/updater-life": "3.9.1",
+        "@tsparticles/updater-rotate": "3.9.1",
+        "@tsparticles/updater-stroke-color": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-color/-/updater-color-3.9.1.tgz",
+      "integrity": "sha512-XGWdscrgEMA8L5E7exsE0f8/2zHKIqnTrZymcyuFBw2DCB6BIV+5z6qaNStpxrhq3DbIxxhqqcybqeOo7+Alpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-life": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-3.9.1.tgz",
+      "integrity": "sha512-Oi8aF2RIwMMsjssUkCB6t3PRpENHjdZf6cX92WNfAuqXtQphr3OMAkYFJFWkvyPFK22AVy3p/cFt6KE5zXxwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-opacity": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-3.9.1.tgz",
+      "integrity": "sha512-w778LQuRZJ+IoWzeRdrGykPYSSaTeWfBvLZ2XwYEkh/Ss961InOxZKIpcS6i5Kp/Zfw0fS1ZAuqeHwuj///Osw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-out-modes": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-3.9.1.tgz",
+      "integrity": "sha512-cKQEkAwbru+hhKF+GTsfbOvuBbx2DSB25CxOdhtW2wRvDBoCnngNdLw91rs+0Cex4tgEeibkebrIKFDDE6kELg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-rotate": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-3.9.1.tgz",
+      "integrity": "sha512-9BfKaGfp28JN82MF2qs6Ae/lJr9EColMfMTHqSKljblwbpVDHte4umuwKl3VjbRt87WD9MGtla66NTUYl+WxuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-size": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-3.9.1.tgz",
+      "integrity": "sha512-3NSVs0O2ApNKZXfd+y/zNhTXSFeG1Pw4peI8e6z/q5+XLbmue9oiEwoPy/tQLaark3oNj3JU7Q903ZijPyXSzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
+    },
+    "node_modules/@tsparticles/updater-stroke-color": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@tsparticles/updater-stroke-color/-/updater-stroke-color-3.9.1.tgz",
+      "integrity": "sha512-3x14+C2is9pZYTg9T2TiA/aM1YMq4wLdYaZDcHm3qO30DZu5oeQq0rm/6w+QOGKYY1Z3Htg9rlSUZkhTHn7eDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsparticles/engine": "3.9.1"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7101,34 +7566,6 @@
         }
       }
     },
-    "node_modules/react-tsparticles": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/react-tsparticles/-/react-tsparticles-2.12.2.tgz",
-      "integrity": "sha512-/nrEbyL8UROXKIMXe+f+LZN2ckvkwV2Qa+GGe/H26oEIc+wq/ybSG9REDwQiSt2OaDQGu0MwmA4BKmkL6wAWcA==",
-      "deprecated": "@tsparticles/react is the new version, please use that",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -8120,565 +8557,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tsparticles": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-2.12.0.tgz",
-      "integrity": "sha512-aw77llkaEhcKYUHuRlggA6SB1Dpa814/nrStp9USGiDo5QwE1Ckq30QAgdXU6GRvnblUFsiO750ZuLQs5Y0tVw==",
-      "deprecated": "tsParticles v3 is out, it contains breaking changes and it's recommended to migrate to that version with fixes and new features",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0",
-        "tsparticles-interaction-external-trail": "^2.12.0",
-        "tsparticles-plugin-absorbers": "^2.12.0",
-        "tsparticles-plugin-emitters": "^2.12.0",
-        "tsparticles-slim": "^2.12.0",
-        "tsparticles-updater-destroy": "^2.12.0",
-        "tsparticles-updater-roll": "^2.12.0",
-        "tsparticles-updater-tilt": "^2.12.0",
-        "tsparticles-updater-twinkle": "^2.12.0",
-        "tsparticles-updater-wobble": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-basic": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-basic/-/tsparticles-basic-2.12.0.tgz",
-      "integrity": "sha512-pN6FBpL0UsIUXjYbiui5+IVsbIItbQGOlwyGV55g6IYJBgdTNXgFX0HRYZGE9ZZ9psEXqzqwLM37zvWnb5AG9g==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0",
-        "tsparticles-move-base": "^2.12.0",
-        "tsparticles-shape-circle": "^2.12.0",
-        "tsparticles-updater-color": "^2.12.0",
-        "tsparticles-updater-opacity": "^2.12.0",
-        "tsparticles-updater-out-modes": "^2.12.0",
-        "tsparticles-updater-size": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-engine": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-engine/-/tsparticles-engine-2.12.0.tgz",
-      "integrity": "sha512-ZjDIYex6jBJ4iMc9+z0uPe7SgBnmb6l+EJm83MPIsOny9lPpetMsnw/8YJ3xdxn8hV+S3myTpTN1CkOVmFv0QQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/tsparticles-interaction-external-attract": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-attract/-/tsparticles-interaction-external-attract-2.12.0.tgz",
-      "integrity": "sha512-0roC6D1QkFqMVomcMlTaBrNVjVOpyNzxIUsjMfshk2wUZDAvTNTuWQdUpmsLS4EeSTDN3rzlGNnIuuUQqyBU5w==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-bounce": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bounce/-/tsparticles-interaction-external-bounce-2.12.0.tgz",
-      "integrity": "sha512-MMcqKLnQMJ30hubORtdq+4QMldQ3+gJu0bBYsQr9BsThsh8/V0xHc1iokZobqHYVP5tV77mbFBD8Z7iSCf0TMQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-bubble": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-bubble/-/tsparticles-interaction-external-bubble-2.12.0.tgz",
-      "integrity": "sha512-5kImCSCZlLNccXOHPIi2Yn+rQWTX3sEa/xCHwXW19uHxtILVJlnAweayc8+Zgmb7mo0DscBtWVFXHPxrVPFDUA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-connect": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-connect/-/tsparticles-interaction-external-connect-2.12.0.tgz",
-      "integrity": "sha512-ymzmFPXz6AaA1LAOL5Ihuy7YSQEW8MzuSJzbd0ES13U8XjiU3HlFqlH6WGT1KvXNw6WYoqrZt0T3fKxBW3/C3A==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-grab": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-grab/-/tsparticles-interaction-external-grab-2.12.0.tgz",
-      "integrity": "sha512-iQF/A947hSfDNqAjr49PRjyQaeRkYgTYpfNmAf+EfME8RsbapeP/BSyF6mTy0UAFC0hK2A2Hwgw72eT78yhXeQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-pause": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-pause/-/tsparticles-interaction-external-pause-2.12.0.tgz",
-      "integrity": "sha512-4SUikNpsFROHnRqniL+uX2E388YTtfRWqqqZxRhY0BrijH4z04Aii3YqaGhJxfrwDKkTQlIoM2GbFT552QZWjw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-push": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-push/-/tsparticles-interaction-external-push-2.12.0.tgz",
-      "integrity": "sha512-kqs3V0dgDKgMoeqbdg+cKH2F+DTrvfCMrPF1MCCUpBCqBiH+TRQpJNNC86EZYHfNUeeLuIM3ttWwIkk2hllR/Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-remove": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-remove/-/tsparticles-interaction-external-remove-2.12.0.tgz",
-      "integrity": "sha512-2eNIrv4m1WB2VfSVj46V2L/J9hNEZnMgFc+A+qmy66C8KzDN1G8aJUAf1inW8JVc0lmo5+WKhzex4X0ZSMghBg==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-repulse": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-repulse/-/tsparticles-interaction-external-repulse-2.12.0.tgz",
-      "integrity": "sha512-rSzdnmgljeBCj5FPp4AtGxOG9TmTsK3AjQW0vlyd1aG2O5kSqFjR+FuT7rfdSk9LEJGH5SjPFE6cwbuy51uEWA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-slow": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-slow/-/tsparticles-interaction-external-slow-2.12.0.tgz",
-      "integrity": "sha512-2IKdMC3om7DttqyroMtO//xNdF0NvJL/Lx7LDo08VpfTgJJozxU+JAUT8XVT7urxhaDzbxSSIROc79epESROtA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-external-trail": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-external-trail/-/tsparticles-interaction-external-trail-2.12.0.tgz",
-      "integrity": "sha512-LKSapU5sPTaZqYx+y5VJClj0prlV7bswplSFQaIW1raXkvsk45qir2AVcpP5JUhZSFSG+SwsHr+qCgXhNeN1KA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-particles-attract": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-attract/-/tsparticles-interaction-particles-attract-2.12.0.tgz",
-      "integrity": "sha512-Hl8qwuwF9aLq3FOkAW+Zomu7Gb8IKs6Y3tFQUQScDmrrSCaeRt2EGklAiwgxwgntmqzL7hbMWNx06CHHcUQKdQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-particles-collisions": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-collisions/-/tsparticles-interaction-particles-collisions-2.12.0.tgz",
-      "integrity": "sha512-Se9nPWlyPxdsnHgR6ap4YUImAu3W5MeGKJaQMiQpm1vW8lSMOUejI1n1ioIaQth9weKGKnD9rvcNn76sFlzGBA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-interaction-particles-links": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-interaction-particles-links/-/tsparticles-interaction-particles-links-2.12.0.tgz",
-      "integrity": "sha512-e7I8gRs4rmKfcsHONXMkJnymRWpxHmeaJIo4g2NaDRjIgeb2AcJSWKWZvrsoLnm7zvaf/cMQlbN6vQwCixYq3A==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-move-base": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-move-base/-/tsparticles-move-base-2.12.0.tgz",
-      "integrity": "sha512-oSogCDougIImq+iRtIFJD0YFArlorSi8IW3HD2gO3USkH+aNn3ZqZNTqp321uB08K34HpS263DTbhLHa/D6BWw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-move-parallax": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-move-parallax/-/tsparticles-move-parallax-2.12.0.tgz",
-      "integrity": "sha512-58CYXaX8Ih5rNtYhpnH0YwU4Ks7gVZMREGUJtmjhuYN+OFr9FVdF3oDIJ9N6gY5a5AnAKz8f5j5qpucoPRcYrQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-particles.js": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-particles.js/-/tsparticles-particles.js-2.12.0.tgz",
-      "integrity": "sha512-LyOuvYdhbUScmA4iDgV3LxA0HzY1DnOwQUy3NrPYO393S2YwdDjdwMod6Btq7EBUjg9FVIh+sZRizgV5elV2dg==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-plugin-absorbers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-plugin-absorbers/-/tsparticles-plugin-absorbers-2.12.0.tgz",
-      "integrity": "sha512-2CkPreaXHrE5VzFlxUKLeRB5t66ff+3jwLJoDFgQcp+R4HOEITo0bBZv2DagGP0QZdYN4grpnQzRBVdB4d1rWA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-plugin-easing-quad": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-plugin-easing-quad/-/tsparticles-plugin-easing-quad-2.12.0.tgz",
-      "integrity": "sha512-2mNqez5pydDewMIUWaUhY5cNQ80IUOYiujwG6qx9spTq1D6EEPLbRNAEL8/ecPdn2j1Um3iWSx6lo340rPkv4Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-plugin-emitters": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-plugin-emitters/-/tsparticles-plugin-emitters-2.12.0.tgz",
-      "integrity": "sha512-fbskYnaXWXivBh9KFReVCfqHdhbNQSK2T+fq2qcGEWpwtDdgujcaS1k2Q/xjZnWNMfVesik4IrqspcL51gNdSA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-circle": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-circle/-/tsparticles-shape-circle-2.12.0.tgz",
-      "integrity": "sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-image": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-image/-/tsparticles-shape-image-2.12.0.tgz",
-      "integrity": "sha512-iCkSdUVa40DxhkkYjYuYHr9MJGVw+QnQuN5UC+e/yBgJQY+1tQL8UH0+YU/h0GHTzh5Sm+y+g51gOFxHt1dj7Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-line": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-line/-/tsparticles-shape-line-2.12.0.tgz",
-      "integrity": "sha512-RcpKmmpKlk+R8mM5wA2v64Lv1jvXtU4SrBDv3vbdRodKbKaWGGzymzav1Q0hYyDyUZgplEK/a5ZwrfrOwmgYGA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-polygon": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-polygon/-/tsparticles-shape-polygon-2.12.0.tgz",
-      "integrity": "sha512-5YEy7HVMt1Obxd/jnlsjajchAlYMr9eRZWN+lSjcFSH6Ibra7h59YuJVnwxOxAobpijGxsNiBX0PuGQnB47pmA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-square": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-square/-/tsparticles-shape-square-2.12.0.tgz",
-      "integrity": "sha512-33vfajHqmlODKaUzyPI/aVhnAOT09V7nfEPNl8DD0cfiNikEuPkbFqgJezJuE55ebtVo7BZPDA9o7GYbWxQNuw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-star": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-star/-/tsparticles-shape-star-2.12.0.tgz",
-      "integrity": "sha512-4sfG/BBqm2qBnPLASl2L5aBfCx86cmZLXeh49Un+TIR1F5Qh4XUFsahgVOG0vkZQa+rOsZPEH04xY5feWmj90g==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-shape-text": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-text/-/tsparticles-shape-text-2.12.0.tgz",
-      "integrity": "sha512-v2/FCA+hyTbDqp2ymFOe97h/NFb2eezECMrdirHWew3E3qlvj9S/xBibjbpZva2gnXcasBwxn0+LxKbgGdP0rA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-slim": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-slim/-/tsparticles-slim-2.12.0.tgz",
-      "integrity": "sha512-27w9aGAAAPKHvP4LHzWFpyqu7wKyulayyaZ/L6Tuuejy4KP4BBEB4rY5GG91yvAPsLtr6rwWAn3yS+uxnBDpkA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/tsparticles"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-basic": "^2.12.0",
-        "tsparticles-engine": "^2.12.0",
-        "tsparticles-interaction-external-attract": "^2.12.0",
-        "tsparticles-interaction-external-bounce": "^2.12.0",
-        "tsparticles-interaction-external-bubble": "^2.12.0",
-        "tsparticles-interaction-external-connect": "^2.12.0",
-        "tsparticles-interaction-external-grab": "^2.12.0",
-        "tsparticles-interaction-external-pause": "^2.12.0",
-        "tsparticles-interaction-external-push": "^2.12.0",
-        "tsparticles-interaction-external-remove": "^2.12.0",
-        "tsparticles-interaction-external-repulse": "^2.12.0",
-        "tsparticles-interaction-external-slow": "^2.12.0",
-        "tsparticles-interaction-particles-attract": "^2.12.0",
-        "tsparticles-interaction-particles-collisions": "^2.12.0",
-        "tsparticles-interaction-particles-links": "^2.12.0",
-        "tsparticles-move-base": "^2.12.0",
-        "tsparticles-move-parallax": "^2.12.0",
-        "tsparticles-particles.js": "^2.12.0",
-        "tsparticles-plugin-easing-quad": "^2.12.0",
-        "tsparticles-shape-circle": "^2.12.0",
-        "tsparticles-shape-image": "^2.12.0",
-        "tsparticles-shape-line": "^2.12.0",
-        "tsparticles-shape-polygon": "^2.12.0",
-        "tsparticles-shape-square": "^2.12.0",
-        "tsparticles-shape-star": "^2.12.0",
-        "tsparticles-shape-text": "^2.12.0",
-        "tsparticles-updater-color": "^2.12.0",
-        "tsparticles-updater-life": "^2.12.0",
-        "tsparticles-updater-opacity": "^2.12.0",
-        "tsparticles-updater-out-modes": "^2.12.0",
-        "tsparticles-updater-rotate": "^2.12.0",
-        "tsparticles-updater-size": "^2.12.0",
-        "tsparticles-updater-stroke-color": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-color": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-color/-/tsparticles-updater-color-2.12.0.tgz",
-      "integrity": "sha512-KcG3a8zd0f8CTiOrylXGChBrjhKcchvDJjx9sp5qpwQK61JlNojNCU35xoaSk2eEHeOvFjh0o3CXWUmYPUcBTQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-destroy": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-destroy/-/tsparticles-updater-destroy-2.12.0.tgz",
-      "integrity": "sha512-6NN3dJhxACvzbIGL4dADbYQSZJmdHfwjujj1uvnxdMbb2x8C/AZzGxiN33smo4jkrZ5VLEWZWCJPJ8aOKjQ2Sg==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-life": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-life/-/tsparticles-updater-life-2.12.0.tgz",
-      "integrity": "sha512-J7RWGHAZkowBHpcLpmjKsxwnZZJ94oGEL2w+wvW1/+ZLmAiFFF6UgU0rHMC5CbHJT4IPx9cbkYMEHsBkcRJ0Bw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-opacity": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-opacity/-/tsparticles-updater-opacity-2.12.0.tgz",
-      "integrity": "sha512-YUjMsgHdaYi4HN89LLogboYcCi1o9VGo21upoqxq19yRy0hRCtx2NhH22iHF/i5WrX6jqshN0iuiiNefC53CsA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-out-modes": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-out-modes/-/tsparticles-updater-out-modes-2.12.0.tgz",
-      "integrity": "sha512-owBp4Gk0JNlSrmp12XVEeBroDhLZU+Uq3szbWlHGSfcR88W4c/0bt0FiH5bHUqORIkw+m8O56hCjbqwj69kpOQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-roll": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-roll/-/tsparticles-updater-roll-2.12.0.tgz",
-      "integrity": "sha512-dxoxY5jP4C9x15BxlUv5/Q8OjUPBiE09ToXRyBxea9aEJ7/iMw6odvi1HuT0H1vTIfV7o1MYawjeCbMycvODKQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-rotate": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-rotate/-/tsparticles-updater-rotate-2.12.0.tgz",
-      "integrity": "sha512-waOFlGFmEZOzsQg4C4VSejNVXGf4dMf3fsnQrEROASGf1FCd8B6WcZau7JtXSTFw0OUGuk8UGz36ETWN72DkCw==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-size": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-size/-/tsparticles-updater-size-2.12.0.tgz",
-      "integrity": "sha512-B0yRdEDd/qZXCGDL/ussHfx5YJ9UhTqNvmS5X2rR2hiZhBAE2fmsXLeWkdtF2QusjPeEqFDxrkGiLOsh6poqRA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-stroke-color": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-stroke-color/-/tsparticles-updater-stroke-color-2.12.0.tgz",
-      "integrity": "sha512-MPou1ZDxsuVq6SN1fbX+aI5yrs6FyP2iPCqqttpNbWyL+R6fik1rL0ab/x02B57liDXqGKYomIbBQVP3zUTW1A==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-tilt": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-tilt/-/tsparticles-updater-tilt-2.12.0.tgz",
-      "integrity": "sha512-HDEFLXazE+Zw+kkKKAiv0Fs9D9sRP61DoCR6jZ36ipea6OBgY7V1Tifz2TSR1zoQkk57ER9+EOQbkSQO+YIPGQ==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-twinkle": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-twinkle/-/tsparticles-updater-twinkle-2.12.0.tgz",
-      "integrity": "sha512-JhK/DO4kTx7IFwMBP2EQY9hBaVVvFnGBvX21SQWcjkymmN1hZ+NdcgUtR9jr4jUiiSNdSl7INaBuGloVjWvOgA==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
-    },
-    "node_modules/tsparticles-updater-wobble": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/tsparticles-updater-wobble/-/tsparticles-updater-wobble-2.12.0.tgz",
-      "integrity": "sha512-85FIRl95ipD3jfIsQdDzcUC5PRMWIrCYqBq69nIy9P8rsNzygn+JK2n+P1VQZowWsZvk0mYjqb9OVQB21Lhf6Q==",
-      "deprecated": "starting from tsparticles v3 the packages are now moved to @tsparticles/package-name instead of tsparticles-package-name",
-      "license": "MIT",
-      "dependencies": {
-        "tsparticles-engine": "^2.12.0"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.22.3",
-    "react-tsparticles": "^2.12.2",
+    "@tsparticles/engine": "^3.0.0",
+    "@tsparticles/react": "^3.0.0",
+    "@tsparticles/slim": "^3.0.0",
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.2.1",
-    "tsparticles": "^2.12.0",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { useChatStore } from "@/store/chatStore";
 
 const ThemeWatcher = () => {
   const theme = useUiStore((state) => state.theme);
+  const density = useUiStore((state) => state.density);
   useEffect(() => {
     const root = document.documentElement;
     root.classList.remove("light", "dark");
@@ -23,11 +24,21 @@ const ThemeWatcher = () => {
     localStorage.setItem("nexuslabs-theme", theme);
   }, [theme]);
   useEffect(() => {
+    document.documentElement.dataset.density = density;
+  }, [density]);
+  useEffect(() => {
     const stored = localStorage.getItem("nexuslabs-theme") as "light" | "dark" | null;
     if (stored) {
       useUiStore.setState({ theme: stored });
     }
+    const storedDensity = localStorage.getItem("nexuslabs-density") as "comfortable" | "compact" | null;
+    if (storedDensity) {
+      useUiStore.setState({ density: storedDensity });
+    }
   }, []);
+  useEffect(() => {
+    localStorage.setItem("nexuslabs-density", density);
+  }, [density]);
   return null;
 };
 

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import type { FormEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { useChatStore } from "@/store/chatStore";
+import { useUiStore } from "@/store/uiStore";
+import { cn } from "@/lib/utils/cn";
 
 const ChatInput = () => {
   const [value, setValue] = useState("");
   const send = useChatStore((state) => state.sendMessage);
+  const density = useUiStore((state) => state.density);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -15,17 +18,25 @@ const ChatInput = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="border-t border-border/60 bg-background/70 p-3">
-      <div className="flex items-center gap-2 rounded-xl border border-border/60 bg-background/60 px-3 py-2">
-        <input
+    <form onSubmit={handleSubmit} className="border-t border-border/60 bg-background/70 px-4 py-4">
+      <div
+        data-density={density}
+        className={cn(
+          "flex flex-col gap-4 rounded-2xl border border-border/60 bg-background/60 p-4",
+          density === "compact" && "gap-3 p-3"
+        )}
+      >
+        <textarea
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none"
+          className="min-h-[110px] w-full resize-none rounded-xl border border-border/40 bg-transparent px-3 py-3 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
           placeholder="Nachricht senden..."
         />
-        <Button type="submit" size="sm" disabled={!value.trim()}>
-          Senden
-        </Button>
+        <div className="flex items-center justify-end">
+          <Button type="submit" disabled={!value.trim()} className="min-w-[120px]">
+            Senden
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/src/components/common/StatTile.tsx
+++ b/src/components/common/StatTile.tsx
@@ -2,6 +2,7 @@ import { motion, useMotionValue, useTransform, animate } from "framer-motion";
 import { useEffect } from "react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
+import { useUiStore } from "@/store/uiStore";
 
 interface StatTileProps {
   label: string;
@@ -11,6 +12,7 @@ interface StatTileProps {
 }
 
 const StatTile = ({ label, value, icon: Icon, accent = "from-primary/40 to-secondary/40" }: StatTileProps) => {
+  const density = useUiStore((state) => state.density);
   const count = useMotionValue(0);
   const rounded = useTransform(count, (latest) => Math.round(latest).toLocaleString("de-DE"));
 
@@ -23,13 +25,16 @@ const StatTile = ({ label, value, icon: Icon, accent = "from-primary/40 to-secon
     <motion.div
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      className={cn("relative overflow-hidden rounded-xl border border-border/60 bg-card/80 p-4", "glass-panel")}
+      className={cn(
+        "relative overflow-hidden rounded-2xl border border-border/60 bg-card/80 p-6 backdrop-blur supports-[backdrop-filter]:bg-card/60",
+        density === "compact" && "p-4"
+      )}
     >
       <div className="absolute inset-0 bg-gradient-to-br from-white/5 via-transparent to-primary/10 opacity-40" />
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
-          <motion.span className="text-2xl font-semibold">{rounded}</motion.span>
+      <div className="relative flex items-start justify-between">
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+          <motion.span className="text-3xl font-semibold tracking-tight">{rounded}</motion.span>
         </div>
         <span className={cn("rounded-full bg-gradient-to-br p-2 text-primary", accent)}>
           <Icon className="h-5 w-5" />

--- a/src/components/forum/CategoryCard.tsx
+++ b/src/components/forum/CategoryCard.tsx
@@ -5,6 +5,8 @@ import { Badge } from "@/components/ui/badge";
 import type { Category } from "@/lib/api/types";
 import type { LucideIcon } from "lucide-react";
 import { Crosshair, Swords, Shield, Sparkles } from "lucide-react";
+import { useUiStore } from "@/store/uiStore";
+import { cn } from "@/lib/utils/cn";
 
 const iconMap: Record<string, LucideIcon> = {
   crosshair: Crosshair,
@@ -15,11 +17,16 @@ const iconMap: Record<string, LucideIcon> = {
 
 const CategoryCard = ({ category }: { category: Category }) => {
   const Icon = iconMap[category.icon ?? "sparkles"] ?? Sparkles;
+  const density = useUiStore((state) => state.density);
+
   return (
     <motion.div variants={hoverLift} initial="rest" whileHover="hover" animate="rest" className="h-full">
       <Link
         to={`/forum/${category.id}`}
-        className="flex h-full flex-col justify-between rounded-2xl border border-border/60 bg-card/70 p-5 transition hover:border-primary/60"
+        className={cn(
+          "flex h-full flex-col justify-between rounded-3xl border border-border/60 bg-card/70 p-6 transition hover:border-primary/60 backdrop-blur supports-[backdrop-filter]:bg-card/60",
+          density === "compact" && "gap-3 rounded-2xl p-4"
+        )}
       >
         <div className="space-y-3">
           <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-primary/15 text-primary">

--- a/src/components/forum/TabsBar.tsx
+++ b/src/components/forum/TabsBar.tsx
@@ -24,13 +24,18 @@ const TabsBar = ({ onChange }: TabsBarProps) => {
 
   return (
     <Tabs value={active} onValueChange={handleChange} className="w-full">
-      <TabsList className="relative flex justify-start gap-1 bg-transparent">
+      <TabsList className="relative flex justify-start gap-1.5 rounded-full bg-card/70 p-1.5 backdrop-blur supports-[backdrop-filter]:bg-card/60">
         {tabs.map((tab) => (
-          <TabsTrigger key={tab.value} value={tab.value} className="relative px-4 py-2">
+          <TabsTrigger
+            key={tab.value}
+            value={tab.value}
+            className="relative rounded-full px-4 py-2 text-sm font-medium transition data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground"
+          >
             {active === tab.value && (
               <motion.div
                 layoutId="activeTabUnderline"
-                className="absolute inset-x-0 bottom-0 h-1 rounded-full bg-gradient-to-r from-primary to-secondary"
+                className="absolute inset-0 rounded-full bg-gradient-to-r from-primary/80 to-secondary/80"
+                transition={{ type: "spring", stiffness: 500, damping: 35 }}
               />
             )}
             <span className="relative z-10">{tab.label}</span>

--- a/src/components/forum/ThreadItem.tsx
+++ b/src/components/forum/ThreadItem.tsx
@@ -3,36 +3,49 @@ import { Badge } from "@/components/ui/badge";
 import { formatRelativeTime } from "@/lib/utils/time";
 import type { ThreadWithMeta } from "@/lib/api/types";
 import { MessageSquare, Eye, Flame } from "lucide-react";
+import { useUiStore } from "@/store/uiStore";
+import { cn } from "@/lib/utils/cn";
 
-const ThreadItem = ({ thread }: { thread: ThreadWithMeta }) => (
-  <Link
-    to={`/thread/${thread.id}`}
-    className="group relative flex flex-col gap-3 rounded-2xl border border-border/60 bg-card/70 p-5 transition hover:border-primary/60"
-  >
-    <div className="flex items-start justify-between gap-4">
-      <div className="space-y-1">
-        <Badge variant="accent" className="capitalize">
-          {thread.tags?.[0] ?? "Thread"}
-        </Badge>
-        <h3 className="text-lg font-semibold leading-tight text-foreground group-hover:text-primary">
-          {thread.title}
-        </h3>
-        <p className="text-sm text-muted-foreground">
-          Zuletzt von <span className="font-semibold">{thread.lastPosterId}</span> kommentiert • {formatRelativeTime(thread.lastPostAt)}
-        </p>
+const ThreadItem = ({ thread }: { thread: ThreadWithMeta }) => {
+  const density = useUiStore((state) => state.density);
+
+  return (
+    <Link
+      to={`/thread/${thread.id}`}
+      className={cn(
+        "group block px-6 py-6 transition hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary",
+        density === "compact" && "px-4 py-4"
+      )}
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <Badge variant="accent" className="rounded-full px-2.5 py-0.5 text-xs capitalize">
+              {thread.tags?.[0] ?? "Thread"}
+            </Badge>
+            <h3 className="text-lg font-semibold tracking-tight text-foreground transition group-hover:text-primary md:text-xl">
+              {thread.title}
+            </h3>
+            <p className="text-sm text-muted-foreground">
+              Zuletzt von <span className="font-semibold">{thread.lastPosterId}</span> kommentiert • {formatRelativeTime(thread.lastPostAt)}
+            </p>
+          </div>
+          <Flame className="mt-1 h-5 w-5 flex-shrink-0 text-orange-400" />
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <MessageSquare className="h-4 w-4" /> {thread.replies} Antworten
+          </span>
+          <span className="flex items-center gap-1">
+            <Eye className="h-4 w-4" /> {thread.views.toLocaleString("de-DE")} Views
+          </span>
+          <span className="flex items-center gap-1">
+            Aktualisiert {formatRelativeTime(thread.updatedAt)}
+          </span>
+        </div>
       </div>
-      <Flame className="h-5 w-5 text-orange-400" />
-    </div>
-    <div className="flex items-center gap-4 text-xs text-muted-foreground">
-      <span className="flex items-center gap-1">
-        <MessageSquare className="h-4 w-4" /> {thread.replies} Antworten
-      </span>
-      <span className="flex items-center gap-1">
-        <Eye className="h-4 w-4" /> {thread.views.toLocaleString("de-DE")} Views
-      </span>
-      <span>{formatRelativeTime(thread.updatedAt)} aktualisiert</span>
-    </div>
-  </Link>
-);
+    </Link>
+  );
+};
 
 export default ThreadItem;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 const Footer = () => (
   <footer className="border-t border-border/60 bg-background/60">
-    <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-4 py-6 text-sm text-muted-foreground sm:flex-row">
+    <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center justify-between gap-4 px-4 py-6 text-sm text-muted-foreground sm:flex-row sm:px-6 lg:px-8">
       <p>&copy; {new Date().getFullYear()} NexusLabs. Für Gamer gebaut.</p>
       <div className="flex items-center gap-4">
         <Link to="/forum" className="hover:text-foreground">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,10 +19,12 @@ const Header = () => {
   const location = useLocation();
   const toggleLeft = useUiStore((state) => state.toggleSidebarLeft);
   const toggleRight = useUiStore((state) => state.toggleSidebarRight);
+  const density = useUiStore((state) => state.density);
+  const toggleDensity = useUiStore((state) => state.toggleDensity);
 
   return (
     <header className="sticky top-0 z-40 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/70">
-      <div className="mx-auto flex w-full max-w-6xl items-center gap-4 px-4 py-3">
+      <div className="mx-auto flex w-full max-w-screen-2xl items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
         <button
           className="flex h-10 w-10 items-center justify-center rounded-lg border border-border/60 bg-background/60 text-muted-foreground lg:hidden"
           onClick={() => toggleLeft(true)}
@@ -52,10 +54,10 @@ const Header = () => {
                 Gast
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuContent align="end" className="w-56">
               <DropdownMenuLabel>Willkommen!</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => navigate("/login")}> 
+              <DropdownMenuItem onClick={() => navigate("/login")}>
                 <LogIn className="mr-2 h-4 w-4" /> Login
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => navigate("/register")}>
@@ -66,6 +68,11 @@ const Header = () => {
               <DropdownMenuItem onClick={() => toggleRight(true)}>
                 <Sparkles className="mr-2 h-4 w-4" />
                 Trends anzeigen
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={toggleDensity}>
+                <MessageSquarePlus className="mr-2 h-4 w-4" />
+                Ansicht: {density === "comfortable" ? "Komfort" : "Kompakt"}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -12,24 +12,47 @@ import {
   SheetHeader,
   SheetTitle
 } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils/cn";
 
 const RootLayout = ({ children }: PropsWithChildren) => {
   const sidebarLeftOpen = useUiStore((state) => state.sidebarLeftOpen);
   const sidebarRightOpen = useUiStore((state) => state.sidebarRightOpen);
   const toggleLeft = useUiStore((state) => state.toggleSidebarLeft);
   const toggleRight = useUiStore((state) => state.toggleSidebarRight);
+  const density = useUiStore((state) => state.density);
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col leading-relaxed tracking-[0.01em]">
       <Header />
       <div className="flex-1">
-        <div className="mx-auto grid w-full max-w-6xl gap-6 px-4 py-8 lg:grid-cols-[260px_minmax(0,1fr)_260px]">
-          <div className="hidden lg:block">
-            <SidebarLeftStats />
-          </div>
-          <div className="min-w-0">{children}</div>
-          <div className="hidden lg:block">
-            <SidebarRightTrends />
+        <div
+          data-density={density}
+          className={cn(
+            "mx-auto w-full max-w-screen-2xl px-4 py-8 sm:px-6 lg:px-8 md:py-12"
+          )}
+        >
+          <div
+            className={cn(
+              "grid grid-cols-1 gap-6 lg:grid-cols-[18rem_minmax(0,1fr)_20rem] lg:gap-8",
+              density === "compact" && "gap-4 lg:gap-6"
+            )}
+          >
+            <div className="hidden lg:block">
+              <SidebarLeftStats />
+            </div>
+            <div className="min-w-0">
+              <div
+                className={cn(
+                  "space-y-6 md:space-y-8",
+                  density === "compact" && "space-y-3 md:space-y-4"
+                )}
+              >
+                {children}
+              </div>
+            </div>
+            <div className="hidden lg:block">
+              <SidebarRightTrends />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/layout/SidebarLeftStats.tsx
+++ b/src/components/layout/SidebarLeftStats.tsx
@@ -6,6 +6,8 @@ import type { Stats } from "@/lib/api/types";
 import { usePresenceStore } from "@/store/presenceStore";
 import LoadingSkeleton from "@/components/common/LoadingSkeleton";
 import ErrorState from "@/components/common/ErrorState";
+import { useUiStore } from "@/store/uiStore";
+import { cn } from "@/lib/utils/cn";
 
 const SidebarLeftStats = () => {
   const [stats, setStats] = useState<Stats | null>(null);
@@ -36,12 +38,17 @@ const SidebarLeftStats = () => {
   if (error) return <ErrorState message={error} onRetry={load} />;
   if (!stats) return null;
 
+  const density = useUiStore((state) => state.density);
+
   return (
-    <aside className="space-y-4">
+    <aside className="space-y-4" data-density={density}>
       <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         Statistik
       </h2>
-      <div className="space-y-3">
+      <div
+        data-density={density}
+        className={cn("grid grid-cols-2 gap-4 md:gap-5", density === "compact" && "gap-3")}
+      >
         <StatTile label="Registrierte Nutzer" value={stats.usersTotal} icon={Users} />
         <StatTile label="Gerade online" value={online} icon={Flame} accent="from-amber-400/40 to-red-500/40" />
         <StatTile label="Kategorien" value={stats.categoriesTotal} icon={Hash} accent="from-primary/40 to-primary/10" />

--- a/src/components/layout/SidebarRightTrends.tsx
+++ b/src/components/layout/SidebarRightTrends.tsx
@@ -7,6 +7,8 @@ import LoadingSkeleton from "@/components/common/LoadingSkeleton";
 import ErrorState from "@/components/common/ErrorState";
 import { Badge } from "@/components/ui/badge";
 import { formatRelativeTime } from "@/lib/utils/time";
+import { useUiStore } from "@/store/uiStore";
+import { cn } from "@/lib/utils/cn";
 
 const SidebarRightTrends = () => {
   const [trending, setTrending] = useState<ThreadWithMeta[]>([]);
@@ -33,19 +35,27 @@ const SidebarRightTrends = () => {
   if (loading && trending.length === 0) return <LoadingSkeleton />;
   if (error) return <ErrorState message={error} onRetry={load} />;
 
+  const density = useUiStore((state) => state.density);
+
   return (
-    <aside className="space-y-4">
+    <aside className="space-y-4" data-density={density}>
       <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         <Flame className="h-4 w-4 text-orange-400" /> Trends
       </h2>
-      <div className="space-y-4">
+      <div
+        className={cn("space-y-4", density === "compact" && "space-y-3")}
+        data-density={density}
+      >
         {trending.map((thread) => (
           <Link
             key={thread.id}
             to={`/thread/${thread.id}`}
-            className="flex flex-col gap-2 rounded-xl border border-border/60 bg-card/70 p-4 transition hover:border-primary/60"
+            className={cn(
+              "flex flex-col gap-3 rounded-3xl border border-border/60 bg-card/70 p-5 backdrop-blur transition hover:border-primary/60 supports-[backdrop-filter]:bg-card/60",
+              density === "compact" && "rounded-2xl p-4"
+            )}
           >
-            <div className="flex items-center justify-between text-sm text-muted-foreground">
+            <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
               <span className="flex items-center gap-1">
                 <Hash className="h-4 w-4" /> {thread.tags?.[0] ?? "Thread"}
               </span>
@@ -53,9 +63,11 @@ const SidebarRightTrends = () => {
                 <Clock className="h-4 w-4" /> {formatRelativeTime(thread.updatedAt)}
               </span>
             </div>
-            <h3 className="line-clamp-2 text-sm font-semibold text-foreground">{thread.title}</h3>
+            <h3 className="line-clamp-2 text-base font-semibold tracking-tight text-foreground">{thread.title}</h3>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <Badge variant="accent">{thread.replies} Antworten</Badge>
+              <Badge variant="accent" className="rounded-full px-2.5 py-0.5">
+                {thread.replies} Antworten
+              </Badge>
               <span>{thread.views.toLocaleString("de-DE")} Views</span>
             </div>
           </Link>

--- a/src/lib/animations/gsapScroll.ts
+++ b/src/lib/animations/gsapScroll.ts
@@ -2,9 +2,11 @@ import { useEffect } from "react";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 
-// Register once globally
-if (typeof window !== "undefined" && !gsap.core.globals()["ScrollTrigger"]) {
+let scrollTriggerRegistered = false;
+
+if (typeof window !== "undefined" && !scrollTriggerRegistered) {
   gsap.registerPlugin(ScrollTrigger);
+  scrollTriggerRegistered = true;
 }
 
 export const useGsapScrollReveal = (selector: string) => {

--- a/src/routes/Forum.tsx
+++ b/src/routes/Forum.tsx
@@ -25,28 +25,34 @@ const Forum = () => {
     void fetchThreads({ sort: activeTab });
   }, [fetchThreads, activeTab]);
 
+  const density = useUiStore((state) => state.density);
+
   return (
     <PageTransition>
-      <div className="space-y-6">
-        <div className="flex flex-col gap-4 rounded-3xl border border-border/60 bg-card/60 p-6 md:flex-row md:items-center md:justify-between">
-          <div>
-            <h1 className="text-2xl font-bold">Forum Übersicht</h1>
+      <div className="mx-auto w-full max-w-3xl space-y-6 md:space-y-8 xl:max-w-4xl">
+        <div
+          data-density={density}
+          className="flex flex-col gap-4 rounded-3xl border border-border/60 bg-card/60 p-6 data-[density=compact]:gap-3 data-[density=compact]:p-3 md:flex-row md:items-center md:justify-between"
+        >
+          <div className="space-y-1">
+            <h1 className="text-3xl font-semibold tracking-tight">Forum Übersicht</h1>
             <p className="text-sm text-muted-foreground">Was passiert gerade in der NexusLabs Community?</p>
           </div>
-          <Button size="lg" onClick={() => navigate("/create")}> 
+          <Button size="lg" onClick={() => navigate("/create")}
+            className="self-start md:self-auto">
             <MessageSquarePlus className="mr-2 h-4 w-4" />
             Neuer Thread
           </Button>
         </div>
 
-        <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</h2>
+        <section className="space-y-4" data-density={density}>
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</h2>
           {loadingCategories && categories.length === 0 ? (
             <LoadingSkeleton />
           ) : error && categories.length === 0 ? (
             <ErrorState message={error} onRetry={() => fetchCategories()} />
           ) : (
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-4 data-[density=compact]:gap-3 md:grid-cols-2 xl:grid-cols-3">
               {categories.map((category) => (
                 <CategoryCard key={category.id} category={category} />
               ))}
@@ -54,7 +60,7 @@ const Forum = () => {
           )}
         </section>
 
-        <section className="space-y-4">
+        <section className="space-y-4" data-density={density}>
           <TabsBar onChange={(value) => fetchThreads({ sort: value as typeof activeTab })} />
           {loadingThreads && threads.length === 0 ? (
             <LoadingSkeleton />
@@ -63,7 +69,7 @@ const Forum = () => {
           ) : threads.length === 0 ? (
             <EmptyState />
           ) : (
-            <div className="space-y-4">
+            <div className="divide-y divide-border/60 overflow-hidden rounded-3xl border border-border/60 bg-card/60 backdrop-blur supports-[backdrop-filter]:bg-card/50">
               {threads.map((thread) => (
                 <ThreadItem key={thread.id} thread={thread} />
               ))}

--- a/src/routes/Landing.tsx
+++ b/src/routes/Landing.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from "react";
-import { loadFull } from "tsparticles";
-import type { Engine } from "tsparticles-engine";
-import { Particles } from "react-tsparticles";
+import { useEffect, useMemo, useState } from "react";
+import Particles, { initParticlesEngine } from "@tsparticles/react";
+import { loadSlim } from "@tsparticles/slim";
+import type { Engine, ISourceOptions } from "@tsparticles/engine";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import PageTransition from "@/components/layout/PageTransition";
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { Sparkles, ArrowRight, Shield } from "lucide-react";
 import { useGsapScrollReveal } from "@/lib/animations/gsapScroll";
 import { mockApi } from "@/lib/api/mockApi";
-import { useEffect, useState } from "react";
 import type { Stats } from "@/lib/api/types";
 
 const features = [
@@ -33,6 +32,7 @@ const features = [
 const Landing = () => {
   const navigate = useNavigate();
   const [stats, setStats] = useState<Stats | null>(null);
+  const [particlesReady, setParticlesReady] = useState(false);
   useGsapScrollReveal("[data-animate-card]");
 
   useEffect(() => {
@@ -43,42 +43,40 @@ const Landing = () => {
     void fetchStats();
   }, []);
 
-  const particlesInit = useCallback(async (engine: Engine) => {
-    await loadFull(engine);
+  useEffect(() => {
+    initParticlesEngine(async (engine: Engine) => {
+      await loadSlim(engine);
+    }).then(() => setParticlesReady(true));
   }, []);
+
+  const particleOptions = useMemo<ISourceOptions>(
+    () => ({
+      background: { color: { value: "transparent" } },
+      fullScreen: { enable: false },
+      particles: {
+        number: { value: 60, density: { enable: true, area: 800 } },
+        move: { enable: true, speed: 1 },
+        links: { enable: true, opacity: 0.3, distance: 140 },
+        opacity: { value: 0.5 },
+        size: { value: { min: 1, max: 3 } }
+      },
+      interactivity: {
+        events: { onHover: { enable: true, mode: "repulse" } },
+        modes: { repulse: { distance: 100 } }
+      }
+    }),
+    []
+  );
 
   return (
     <PageTransition>
-      <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-background/80 via-background/60 to-background/90 py-24">
-        <Particles
-          id="tsparticles"
-          init={particlesInit}
-          className="absolute inset-0 -z-10"
-          options={{
-            fullScreen: { enable: false },
-            background: { color: "transparent" },
-            fpsLimit: 60,
-            interactivity: {
-              events: {
-                onHover: { enable: true, mode: "repulse" },
-                onClick: { enable: true, mode: "push" }
-              },
-              modes: {
-                repulse: { distance: 80 },
-                push: { quantity: 2 }
-              }
-            },
-            particles: {
-              color: { value: ["#00E0FF", "#7C3AED"] },
-              links: { enable: true, color: "#7C3AED", opacity: 0.4, distance: 130 },
-              move: { enable: true, speed: 1.2 },
-              number: { value: 80 },
-              opacity: { value: 0.6 },
-              size: { value: { min: 1, max: 3 } }
-            }
-          }}
-        />
-        <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-12 px-6 text-center">
+      <section className="relative isolate overflow-hidden rounded-3xl border border-border/60 bg-gradient-to-br from-background/80 via-background/60 to-background/90 py-24">
+        {particlesReady && (
+          <div className="pointer-events-none absolute inset-0 -z-10" aria-hidden="true">
+            <Particles id="tsparticles" options={particleOptions} />
+          </div>
+        )}
+        <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center gap-12 px-6 text-center">
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -88,7 +86,7 @@ const Landing = () => {
             <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs uppercase tracking-wide text-primary">
               NexusLabs – The Next-Gen Gaming Forum
             </span>
-            <h1 className="text-4xl font-bold leading-tight text-foreground md:text-5xl">
+            <h1 className="text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
               Verbinde dich mit der Elite der Gaming-Community
             </h1>
             <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
@@ -112,11 +110,11 @@ const Landing = () => {
           </motion.div>
         </div>
       </section>
-      <section className="mx-auto mt-16 grid w-full max-w-5xl gap-6 px-4 md:grid-cols-3">
+      <section className="mx-auto mt-16 grid w-full max-w-screen-2xl gap-6 px-4 md:grid-cols-3 md:gap-7">
         {features.map((feature, index) => (
           <motion.div
             key={feature.title}
-            className="rounded-3xl border border-border/60 bg-card/70 p-6"
+            className="rounded-3xl border border-border/60 bg-card/70 p-6 backdrop-blur supports-[backdrop-filter]:bg-card/60"
             data-animate-card
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -3,16 +3,21 @@ import { persist } from "zustand/middleware";
 
 type Theme = "dark" | "light";
 
+type Density = "comfortable" | "compact";
+
 type UiStore = {
   theme: Theme;
   sidebarLeftOpen: boolean;
   sidebarRightOpen: boolean;
   activeTab: "new" | "top" | "active" | "unread";
+  density: Density;
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
   setActiveTab: (tab: UiStore["activeTab"]) => void;
   toggleSidebarLeft: (open?: boolean) => void;
   toggleSidebarRight: (open?: boolean) => void;
+  setDensity: (density: Density) => void;
+  toggleDensity: () => void;
 };
 
 export const useUiStore = create<UiStore>()(
@@ -22,13 +27,17 @@ export const useUiStore = create<UiStore>()(
       sidebarLeftOpen: false,
       sidebarRightOpen: false,
       activeTab: "new",
+      density: "comfortable",
       setTheme: (theme) => set({ theme }),
       toggleTheme: () => set({ theme: get().theme === "dark" ? "light" : "dark" }),
       setActiveTab: (activeTab) => set({ activeTab }),
       toggleSidebarLeft: (open) =>
         set(({ sidebarLeftOpen }) => ({ sidebarLeftOpen: open ?? !sidebarLeftOpen })),
       toggleSidebarRight: (open) =>
-        set(({ sidebarRightOpen }) => ({ sidebarRightOpen: open ?? !sidebarRightOpen }))
+        set(({ sidebarRightOpen }) => ({ sidebarRightOpen: open ?? !sidebarRightOpen })),
+      setDensity: (density) => set({ density }),
+      toggleDensity: () =>
+        set(({ density }) => ({ density: density === "comfortable" ? "compact" : "comfortable" }))
     }),
     { name: "nexuslabs-ui" }
   )

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- replace legacy tsparticles packages with the v3 @tsparticles suite and update the landing hero to initialise the slim bundle safely
- introduce a density preference with a header toggle and propagate new spacing/containers for landing, forum grid, sidebars, and cards
- harden the realtime mock by generating stable ids, guarding strict-mode double starts, and tightening chat composer styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7f6067c6883279fdb16679d6187a1