### PR TITLE
Fix hook order in sidebar components

### DIFF
--- a/src/components/layout/SidebarLeftStats.tsx
+++ b/src/components/layout/SidebarLeftStats.tsx
@@ -34,11 +34,11 @@ const SidebarLeftStats = () => {
     return () => clearInterval(interval);
   }, []);
 
+  const density = useUiStore((state) => state.density);
+
   if (loading && !stats) return <LoadingSkeleton />;
   if (error) return <ErrorState message={error} onRetry={load} />;
   if (!stats) return null;
-
-  const density = useUiStore((state) => state.density);
 
   return (
     <aside className="space-y-4" data-density={density}>

--- a/src/components/layout/SidebarRightTrends.tsx
+++ b/src/components/layout/SidebarRightTrends.tsx
@@ -32,10 +32,10 @@ const SidebarRightTrends = () => {
     void load();
   }, []);
 
+  const density = useUiStore((state) => state.density);
+
   if (loading && trending.length === 0) return <LoadingSkeleton />;
   if (error) return <ErrorState message={error} onRetry={load} />;
-
-  const density = useUiStore((state) => state.density);
 
   return (
     <aside className="space-y-4" data-density={density}>


### PR DESCRIPTION
## Summary
- ensure the UI density selector hook is invoked before any early returns in the sidebar components
- prevent the hook order errors that occurred once data finished loading

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d80347e2248327be429fb472f0812e