### PR TITLE
Fix chat duplication and stabilize message IDs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import Login from "@/routes/Auth/Login";
 import Register from "@/routes/Auth/Register";
 import { useUiStore } from "@/store/uiStore";
 import { usePresenceSubscription } from "@/lib/realtime/presence";
-import { useChatStore } from "@/store/chatStore";
 
 const ThemeWatcher = () => {
   const theme = useUiStore((state) => state.theme);
@@ -45,10 +44,6 @@ const ThemeWatcher = () => {
 const App = () => {
   usePresenceSubscription();
   const location = useLocation();
-  const initChat = useChatStore((state) => state.init);
-  useEffect(() => {
-    void initChat();
-  }, [initChat]);
 
   return (
     <RootLayout>

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -4,16 +4,28 @@ import { Button } from "@/components/ui/button";
 import { useChatStore } from "@/store/chatStore";
 import { useUiStore } from "@/store/uiStore";
 import { cn } from "@/lib/utils/cn";
+import { newId } from "@/lib/utils/id";
+import type { ChatMessage } from "@/lib/api/types";
 
 const ChatInput = () => {
   const [value, setValue] = useState("");
-  const send = useChatStore((state) => state.sendMessage);
+  const addMessage = useChatStore((state) => state.addMessage);
   const density = useUiStore((state) => state.density);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!value.trim()) return;
-    send(value.trim());
+    const message: ChatMessage = {
+      id: newId("user"),
+      text: value.trim(),
+      createdAt: new Date().toISOString(),
+      author: {
+        id: "user-self",
+        name: "Du",
+        avatarUrl: "https://i.pravatar.cc/150?img=5",
+      },
+    };
+    addMessage(message);
     setValue("");
   };
 

--- a/src/lib/api/mockApi.ts
+++ b/src/lib/api/mockApi.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { newId } from "../utils/id";
 import type {
   Category,
   ChatMessage,
@@ -141,13 +142,13 @@ const stats: Stats = {
 
 const systemMessages: ChatMessage[] = [
   {
-    id: nanoid(),
+    id: newId("system"),
     text: "Patch 1.27 Notes sind jetzt live!",
     system: true,
     createdAt: nowIso()
   },
   {
-    id: nanoid(),
+    id: newId("system"),
     text: "Community Turnier startet heute um 20:00 Uhr.",
     system: true,
     createdAt: nowIso()

--- a/src/lib/realtime/presence.ts
+++ b/src/lib/realtime/presence.ts
@@ -1,17 +1,20 @@
 import { useEffect } from "react";
-import { socketMock } from "./socketMock";
+import { on, startMock, stopMock } from "./socketMock";
 import { usePresenceStore } from "@/store/presenceStore";
 
 export const usePresenceSubscription = () => {
   const setOnline = usePresenceStore((state) => state.setOnlineCount);
 
   useEffect(() => {
-    const handler = (count: number) => setOnline(count);
-    socketMock.on("presence:update", handler);
-    socketMock.connect();
+    startMock();
+    const off = on("presence:update", (payload) => {
+      if (typeof payload?.online === "number") {
+        setOnline(payload.online);
+      }
+    });
     return () => {
-      socketMock.off("presence:update", handler);
-      socketMock.disconnect();
+      off();
+      stopMock();
     };
   }, [setOnline]);
 };

--- a/src/lib/realtime/socketMock.ts
+++ b/src/lib/realtime/socketMock.ts
@@ -1,94 +1,61 @@
-let msgCounter = 0;
+import type { ChatMessage } from "@/lib/api/types";
+import { newId } from "@/lib/utils/id";
 
-const generateId = () => {
-  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
-    return crypto.randomUUID();
-  }
-  msgCounter += 1;
-  return `msg_${Date.now()}_${msgCounter}`;
+type Handler = (payload: any) => void;
+
+const handlers: Record<string, Set<Handler>> = {
+  "chat:message": new Set(),
+  "presence:update": new Set(),
 };
 
-type Listener<T> = (payload: T) => void;
+let started = false;
+let chatInterval: number | undefined;
+let presenceInterval: number | undefined;
 
-type EventMap = {
-  "presence:update": number;
-  "chat:message": {
-    id: string;
-    text: string;
-    author?: { id: string; name: string; avatarUrl?: string };
-    system?: boolean;
-    createdAt: string;
-  };
-};
-
-class SocketMock {
-  private listeners: { [K in keyof EventMap]?: Listener<EventMap[K]>[] } = {};
-  private presenceInterval?: ReturnType<typeof setInterval>;
-  private chatInterval?: ReturnType<typeof setInterval>;
-  private connections = 0;
-  private started = false;
-
-  connect() {
-    this.connections += 1;
-    if (this.started) return;
-    this.started = true;
-    this.startPresence();
-    this.startChat();
-  }
-
-  disconnect() {
-    this.connections = Math.max(0, this.connections - 1);
-    if (this.connections === 0 && this.started) {
-      if (this.presenceInterval) clearInterval(this.presenceInterval);
-      if (this.chatInterval) clearInterval(this.chatInterval);
-      this.presenceInterval = undefined;
-      this.chatInterval = undefined;
-      this.started = false;
-    }
-  }
-
-  on<K extends keyof EventMap>(event: K, cb: Listener<EventMap[K]>) {
-    if (!this.listeners[event]) this.listeners[event] = [];
-    this.listeners[event]!.push(cb);
-  }
-
-  off<K extends keyof EventMap>(event: K, cb: Listener<EventMap[K]>) {
-    const listeners = this.listeners[event];
-    if (!listeners) return;
-    const filtered = listeners.filter((listener) => listener !== cb);
-    this.listeners[event] = (filtered.length > 0 ? filtered : undefined) as typeof this.listeners[K];
-  }
-
-  emit<K extends keyof EventMap>(event: K, payload: EventMap[K]) {
-    (this.listeners[event] || []).forEach((listener) => listener(payload));
-  }
-
-  private startPresence() {
-    this.presenceInterval = setInterval(() => {
-      const base = 140;
-      const variance = Math.round(Math.random() * 24 - 12);
-      this.emit("presence:update", base + variance);
-    }, 3200);
-  }
-
-  private startChat() {
-    const sampleMessages = [
-      "Wer ist heute Abend beim Raid dabei?",
-      "Checkt den neuen Speedrun-Guide im RPG-Bereich!",
-      "Scrim Lobby öffnet in 10 Minuten.",
-      "Neues Highlight-Video ist im Media-Thread live.",
-      "Wir testen morgen die Crossplay-Beta."
-    ];
-    this.chatInterval = setInterval(() => {
-      const message = sampleMessages[Math.floor(Math.random() * sampleMessages.length)];
-      this.emit("chat:message", {
-        id: generateId(),
-        text: message,
-        system: Math.random() > 0.75,
-        createdAt: new Date().toISOString()
-      });
-    }, 4200 + Math.random() * 2600);
-  }
+export function on(event: keyof typeof handlers, cb: Handler) {
+  handlers[event].add(cb);
+  return () => handlers[event].delete(cb);
 }
 
-export const socketMock = new SocketMock();
+function emit(event: keyof typeof handlers, payload: any) {
+  handlers[event].forEach((cb) => cb(payload));
+}
+
+export function startMock() {
+  if (started) return;
+  started = true;
+
+  chatInterval = window.setInterval(() => {
+    const msg: ChatMessage = {
+      id: newId("msg"),
+      text: sampleText(),
+      createdAt: new Date().toISOString(),
+      system: Math.random() < 0.2,
+      author: { id: "sys", name: "System" },
+    };
+    emit("chat:message", msg);
+  }, 4500 + Math.random() * 2500) as unknown as number;
+
+  presenceInterval = window.setInterval(() => {
+    emit("presence:update", { online: 100 + Math.floor(Math.random() * 30) });
+  }, 3000) as unknown as number;
+}
+
+export function stopMock() {
+  if (chatInterval) clearInterval(chatInterval);
+  if (presenceInterval) clearInterval(presenceInterval);
+  chatInterval = undefined;
+  presenceInterval = undefined;
+  started = false;
+}
+
+function sampleText() {
+  const pool = [
+    "Welcome to NexusLabs!",
+    "New thread just dropped 👀",
+    "Ping spike on EU servers.",
+    "Patch notes live.",
+    "Party up for M+?",
+  ];
+  return pool[Math.floor(Math.random() * pool.length)];
+}

--- a/src/lib/utils/dedupe.ts
+++ b/src/lib/utils/dedupe.ts
@@ -1,0 +1,11 @@
+export function dedupeById<T extends { id: string }>(arr: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const item of arr) {
+    if (!item?.id) continue;
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    out.push(item);
+  }
+  return out;
+}

--- a/src/lib/utils/id.ts
+++ b/src/lib/utils/id.ts
@@ -1,0 +1,8 @@
+let __ctr = 0;
+export function newId(prefix = "msg") {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return `${prefix}_${crypto.randomUUID()}`;
+  }
+  __ctr += 1;
+  return `${prefix}_${Date.now()}_${__ctr}`;
+}


### PR DESCRIPTION
## Summary
- add stable ID and dedupe helpers and convert the chat store to a map-backed cache to prevent duplicate keys
- harden the mock realtime socket and presence subscription against StrictMode double mounts and reuse stable message IDs
- update the chat dock and input to use the new store, load seeded messages once, and render lists with AnimatePresence using real IDs

## Testing
- npm run build *(fails: missing @tsparticles/* dependencies in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d8080881e48327a7a5d2df4365b7aa