### PR TITLE
Refactor forum layout for spacious three-column design

### DIFF
--- a/src/components/chat/ChatDock.tsx
+++ b/src/components/chat/ChatDock.tsx
@@ -8,8 +8,13 @@ import { useChatStore } from "@/store/chatStore";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { on, startMock, stopMock } from "@/lib/realtime/socketMock";
 import { mockApi } from "@/lib/api/mockApi";
+import { cn } from "@/lib/utils/cn";
 
-const ChatDock = () => {
+type ChatDockProps = {
+  className?: string;
+};
+
+const ChatDock = ({ className }: ChatDockProps) => {
   const [open, setOpen] = useState(true);
   const messages = useChatStore((state) => state.ordered());
   const addMessage = useChatStore((state) => state.addMessage);
@@ -43,7 +48,7 @@ const ChatDock = () => {
   }, [messages]);
 
   return (
-    <div className="fixed bottom-4 right-4 z-40 flex w-full max-w-sm flex-col gap-2 sm:right-6">
+    <div className={cn("flex w-full max-w-[min(100vw-3rem,380px)] flex-col gap-2", className)}>
       <AnimatePresence initial={false}>
         {open && (
           <motion.div
@@ -52,11 +57,11 @@ const ChatDock = () => {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.25 }}
-            className="glass-panel flex h-[420px] flex-col rounded-2xl border border-border/60 bg-background/90 shadow-xl backdrop-blur"
+            className="glass-panel flex h-[420px] flex-col rounded-3xl border border-border/60 bg-background/90 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] backdrop-blur supports-[backdrop-filter]:bg-background/80"
           >
             <ChatHeader onMinimize={() => setOpen(false)} />
             <ScrollArea className="flex-1">
-              <div className="space-y-3 px-4 py-3">
+              <div className="space-y-3 p-3 md:p-4">
                 <AnimatePresence initial={false}>
                   {messages.map((message) => (
                     <motion.div

--- a/src/components/forum/CategoryCard.tsx
+++ b/src/components/forum/CategoryCard.tsx
@@ -6,7 +6,6 @@ import type { Category } from "@/lib/api/types";
 import type { LucideIcon } from "lucide-react";
 import { Crosshair, Swords, Shield, Sparkles } from "lucide-react";
 import { useUiStore } from "@/store/uiStore";
-import { cn } from "@/lib/utils/cn";
 
 const iconMap: Record<string, LucideIcon> = {
   crosshair: Crosshair,
@@ -23,21 +22,19 @@ const CategoryCard = ({ category }: { category: Category }) => {
     <motion.div variants={hoverLift} initial="rest" whileHover="hover" animate="rest" className="h-full">
       <Link
         to={`/forum/${category.id}`}
-        className={cn(
-          "flex h-full flex-col justify-between rounded-3xl border border-border/60 bg-card/70 p-6 transition hover:border-primary/60 backdrop-blur supports-[backdrop-filter]:bg-card/60",
-          density === "compact" && "gap-3 rounded-2xl p-4"
-        )}
+        data-density={density}
+        className="flex h-full flex-col justify-between gap-6 rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] transition hover:border-primary/60 supports-[backdrop-filter]:bg-background/70 md:p-6 2xl:p-7 data-[density=compact]:gap-4 data-[density=compact]:rounded-2xl data-[density=compact]:p-4"
       >
-        <div className="space-y-3">
+        <div className="space-y-4">
           <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-primary/15 text-primary">
             <Icon className="h-6 w-6" />
           </span>
-          <div>
-            <h3 className="text-lg font-semibold text-foreground">{category.name}</h3>
-            <p className="text-sm text-muted-foreground">{category.description}</p>
+          <div className="space-y-2">
+            <h3 className="text-xl font-semibold tracking-tight text-foreground 2xl:text-[1.35rem]">{category.name}</h3>
+            <p className="text-sm text-muted-foreground leading-relaxed">{category.description}</p>
           </div>
         </div>
-        <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Badge variant="accent">{category.threadCount} Threads</Badge>
           <span>{category.postCount} Posts</span>
         </div>

--- a/src/components/forum/ThreadItem.tsx
+++ b/src/components/forum/ThreadItem.tsx
@@ -4,7 +4,6 @@ import { formatRelativeTime } from "@/lib/utils/time";
 import type { ThreadWithMeta } from "@/lib/api/types";
 import { MessageSquare, Eye, Flame } from "lucide-react";
 import { useUiStore } from "@/store/uiStore";
-import { cn } from "@/lib/utils/cn";
 
 const ThreadItem = ({ thread }: { thread: ThreadWithMeta }) => {
   const density = useUiStore((state) => state.density);
@@ -12,21 +11,19 @@ const ThreadItem = ({ thread }: { thread: ThreadWithMeta }) => {
   return (
     <Link
       to={`/thread/${thread.id}`}
-      className={cn(
-        "group block px-6 py-6 transition hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary",
-        density === "compact" && "px-4 py-4"
-      )}
+      data-density={density}
+      className="group block rounded-none px-5 py-5 transition hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary md:px-6 md:py-6 data-[density=compact]:px-4 data-[density=compact]:py-4"
     >
-      <div className="flex flex-col gap-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-3">
             <Badge variant="accent" className="rounded-full px-2.5 py-0.5 text-xs capitalize">
               {thread.tags?.[0] ?? "Thread"}
             </Badge>
-            <h3 className="text-lg font-semibold tracking-tight text-foreground transition group-hover:text-primary md:text-xl">
+            <h3 className="text-lg font-semibold tracking-tight text-foreground transition group-hover:text-primary md:text-xl 2xl:text-[1.35rem]">
               {thread.title}
             </h3>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-muted-foreground leading-relaxed">
               Zuletzt von <span className="font-semibold">{thread.lastPosterId}</span> kommentiert • {formatRelativeTime(thread.lastPostAt)}
             </p>
           </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 
 const Footer = () => (
   <footer className="border-t border-border/60 bg-background/60">
-    <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center justify-between gap-4 px-4 py-6 text-sm text-muted-foreground sm:flex-row sm:px-6 lg:px-8">
+    <div className="mx-auto flex w-full max-w-[1600px] flex-col items-center justify-between gap-4 px-4 py-6 text-sm text-muted-foreground sm:flex-row sm:px-6 lg:px-8 2xl:max-w-[1720px] 2xl:px-10 3xl:max-w-[1880px]">
       <p>&copy; {new Date().getFullYear()} NexusLabs. Für Gamer gebaut.</p>
       <div className="flex items-center gap-4">
         <Link to="/forum" className="hover:text-foreground">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,7 +24,7 @@ const Header = () => {
 
   return (
     <header className="sticky top-0 z-40 border-b border-border/60 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/70">
-      <div className="mx-auto flex w-full max-w-screen-2xl items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
+      <div className="mx-auto flex h-16 w-full max-w-[1600px] items-center gap-4 px-4 sm:px-6 lg:h-[72px] lg:px-8 2xl:max-w-[1720px] 2xl:px-10 3xl:max-w-[1880px]">
         <button
           className="flex h-10 w-10 items-center justify-center rounded-lg border border-border/60 bg-background/60 text-muted-foreground lg:hidden"
           onClick={() => toggleLeft(true)}

--- a/src/components/layout/PageTransition.tsx
+++ b/src/components/layout/PageTransition.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from "react";
 import { pageTransition } from "@/lib/animations/framer";
 
 const PageTransition = ({ children }: PropsWithChildren) => (
-  <motion.main
+  <motion.section
     variants={pageTransition}
     initial="initial"
     animate="animate"
@@ -11,7 +11,7 @@ const PageTransition = ({ children }: PropsWithChildren) => (
     className="min-h-[calc(100vh-6rem)]"
   >
     {children}
-  </motion.main>
+  </motion.section>
 );
 
 export default PageTransition;

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -22,49 +22,61 @@ const RootLayout = ({ children }: PropsWithChildren) => {
   const density = useUiStore((state) => state.density);
 
   return (
-    <div className="flex min-h-screen flex-col leading-relaxed tracking-[0.01em]">
+    <div className="flex min-h-screen flex-col">
       <Header />
-      <div className="flex-1">
-        <div
+      <div className="flex-1 pt-4 md:pt-6">
+        <main
           data-density={density}
-          className={cn(
-            "mx-auto w-full max-w-screen-2xl px-4 py-8 sm:px-6 lg:px-8 md:py-12"
-          )}
+          className="mx-auto max-w-[1600px] px-4 sm:px-6 lg:px-8 2xl:max-w-[1720px] 2xl:px-10 3xl:max-w-[1880px]"
         >
           <div
             className={cn(
-              "grid grid-cols-1 gap-6 lg:grid-cols-[18rem_minmax(0,1fr)_20rem] lg:gap-8",
-              density === "compact" && "gap-4 lg:gap-6"
+              "grid grid-cols-1 gap-6 items-start lg:grid-cols-[300px_minmax(640px,1fr)_380px] xl:gap-8 2xl:gap-10",
+              density === "compact" && "gap-5 xl:gap-6 2xl:gap-8"
             )}
           >
-            <div className="hidden lg:block">
+            <aside
+              className={cn(
+                "sticky top-24 hidden space-y-4 lg:block",
+                density === "compact" && "space-y-3"
+              )}
+              data-density={density}
+            >
               <SidebarLeftStats />
-            </div>
-            <div className="min-w-0">
-              <div
-                className={cn(
-                  "space-y-6 md:space-y-8",
-                  density === "compact" && "space-y-3 md:space-y-4"
-                )}
-              >
-                {children}
-              </div>
-            </div>
-            <div className="hidden lg:block">
+            </aside>
+            <section
+              className={cn(
+                "mx-auto w-full max-w-[960px] space-y-6 md:space-y-8 2xl:max-w-[1040px]",
+                "lg:col-span-2 xl:col-span-1",
+                density === "compact" && "space-y-4 md:space-y-5"
+              )}
+              data-density={density}
+            >
+              {children}
+            </section>
+            <aside
+              className={cn(
+                "sticky top-24 hidden space-y-4 xl:block w-[340px] xl:w-[360px] 2xl:w-[380px]",
+                density === "compact" && "space-y-3"
+              )}
+              data-density={density}
+            >
               <SidebarRightTrends />
-            </div>
+            </aside>
           </div>
-        </div>
+        </main>
       </div>
       <Footer />
-      <ChatDock />
+      <div className="fixed bottom-6 right-6 z-40">
+        <ChatDock className="w-[360px] 2xl:w-[380px]" />
+      </div>
 
       <Sheet open={sidebarLeftOpen} onOpenChange={(open) => toggleLeft(open)}>
         <SheetContent className="left-0 right-auto w-full max-w-sm border-r">
           <SheetHeader>
             <SheetTitle>Statistiken</SheetTitle>
           </SheetHeader>
-          <div className="mt-6 space-y-4">
+          <div className="mt-6 space-y-4 md:space-y-5">
             <SidebarLeftStats />
             <SheetClose className="mt-4 rounded-md border border-border/60 px-4 py-2 text-sm">
               Schließen
@@ -78,7 +90,7 @@ const RootLayout = ({ children }: PropsWithChildren) => {
           <SheetHeader>
             <SheetTitle>Trends &amp; Highlights</SheetTitle>
           </SheetHeader>
-          <div className="mt-6 space-y-4">
+          <div className="mt-6 space-y-4 md:space-y-5">
             <SidebarRightTrends />
             <SheetClose className="mt-4 rounded-md border border-border/60 px-4 py-2 text-sm">
               Schließen

--- a/src/components/layout/SidebarLeftStats.tsx
+++ b/src/components/layout/SidebarLeftStats.tsx
@@ -41,13 +41,14 @@ const SidebarLeftStats = () => {
   if (!stats) return null;
 
   return (
-    <aside className="space-y-4" data-density={density}>
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-        Statistik
-      </h2>
+    <div className="space-y-5 data-[density=compact]:space-y-3 2xl:space-y-6" data-density={density}>
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Statistik</h2>
       <div
         data-density={density}
-        className={cn("grid grid-cols-2 gap-4 md:gap-5", density === "compact" && "gap-3")}
+        className={cn(
+          "grid grid-cols-2 gap-4 md:gap-5",
+          "data-[density=compact]:gap-3 md:data-[density=compact]:gap-4"
+        )}
       >
         <StatTile label="Registrierte Nutzer" value={stats.usersTotal} icon={Users} />
         <StatTile label="Gerade online" value={online} icon={Flame} accent="from-amber-400/40 to-red-500/40" />
@@ -55,7 +56,7 @@ const SidebarLeftStats = () => {
         <StatTile label="Threads" value={stats.threadsTotal} icon={TrendingUp} accent="from-secondary/40 to-secondary/10" />
         <StatTile label="Beiträge" value={stats.postsTotal} icon={MessageSquare} accent="from-emerald-400/40 to-primary/10" />
       </div>
-    </aside>
+    </div>
   );
 };
 

--- a/src/components/layout/SidebarRightTrends.tsx
+++ b/src/components/layout/SidebarRightTrends.tsx
@@ -8,7 +8,6 @@ import ErrorState from "@/components/common/ErrorState";
 import { Badge } from "@/components/ui/badge";
 import { formatRelativeTime } from "@/lib/utils/time";
 import { useUiStore } from "@/store/uiStore";
-import { cn } from "@/lib/utils/cn";
 
 const SidebarRightTrends = () => {
   const [trending, setTrending] = useState<ThreadWithMeta[]>([]);
@@ -38,22 +37,17 @@ const SidebarRightTrends = () => {
   if (error) return <ErrorState message={error} onRetry={load} />;
 
   return (
-    <aside className="space-y-4" data-density={density}>
+    <div className="space-y-5 data-[density=compact]:space-y-3 2xl:space-y-6" data-density={density}>
       <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         <Flame className="h-4 w-4 text-orange-400" /> Trends
       </h2>
-      <div
-        className={cn("space-y-4", density === "compact" && "space-y-3")}
-        data-density={density}
-      >
+      <div className="space-y-4 md:space-y-5 data-[density=compact]:space-y-3 2xl:space-y-6" data-density={density}>
         {trending.map((thread) => (
           <Link
             key={thread.id}
             to={`/thread/${thread.id}`}
-            className={cn(
-              "flex flex-col gap-3 rounded-3xl border border-border/60 bg-card/70 p-5 backdrop-blur transition hover:border-primary/60 supports-[backdrop-filter]:bg-card/60",
-              density === "compact" && "rounded-2xl p-4"
-            )}
+            data-density={density}
+            className="group flex flex-col gap-4 rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] backdrop-blur transition hover:border-primary/60 supports-[backdrop-filter]:bg-background/70 md:p-6 2xl:p-7 data-[density=compact]:gap-3 data-[density=compact]:rounded-2xl data-[density=compact]:p-4"
           >
             <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
               <span className="flex items-center gap-1">
@@ -63,8 +57,10 @@ const SidebarRightTrends = () => {
                 <Clock className="h-4 w-4" /> {formatRelativeTime(thread.updatedAt)}
               </span>
             </div>
-            <h3 className="line-clamp-2 text-base font-semibold tracking-tight text-foreground">{thread.title}</h3>
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <h3 className="line-clamp-2 text-xl font-semibold tracking-tight text-foreground transition group-hover:text-primary 2xl:text-[1.35rem]">
+              {thread.title}
+            </h3>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               <Badge variant="accent" className="rounded-full px-2.5 py-0.5">
                 {thread.replies} Antworten
               </Badge>
@@ -73,7 +69,7 @@ const SidebarRightTrends = () => {
           </Link>
         ))}
       </div>
-    </aside>
+    </div>
   );
 };
 

--- a/src/routes/Forum.tsx
+++ b/src/routes/Forum.tsx
@@ -29,30 +29,36 @@ const Forum = () => {
 
   return (
     <PageTransition>
-      <div className="mx-auto w-full max-w-3xl space-y-6 md:space-y-8 xl:max-w-4xl">
+      <div className="space-y-6 md:space-y-8 data-[density=compact]:space-y-4 md:data-[density=compact]:space-y-5" data-density={density}>
         <div
+          className="mx-auto w-full max-w-[1040px] rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] supports-[backdrop-filter]:bg-background/70 md:p-6 2xl:p-7 data-[density=compact]:p-4 md:data-[density=compact]:p-5"
           data-density={density}
-          className="flex flex-col gap-4 rounded-3xl border border-border/60 bg-card/60 p-6 data-[density=compact]:gap-3 data-[density=compact]:p-3 md:flex-row md:items-center md:justify-between"
         >
-          <div className="space-y-1">
-            <h1 className="text-3xl font-semibold tracking-tight">Forum Übersicht</h1>
-            <p className="text-sm text-muted-foreground">Was passiert gerade in der NexusLabs Community?</p>
+          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between data-[density=compact]:gap-4" data-density={density}>
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight">Forum Übersicht</h1>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Was passiert gerade in der NexusLabs Community?
+              </p>
+            </div>
+            <Button size="lg" onClick={() => navigate("/create")} className="self-start md:self-auto">
+              <MessageSquarePlus className="mr-2 h-4 w-4" />
+              Neuer Thread
+            </Button>
           </div>
-          <Button size="lg" onClick={() => navigate("/create")}
-            className="self-start md:self-auto">
-            <MessageSquarePlus className="mr-2 h-4 w-4" />
-            Neuer Thread
-          </Button>
         </div>
 
-        <section className="space-y-4" data-density={density}>
+        <section className="space-y-5 data-[density=compact]:space-y-4" data-density={density}>
           <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</h2>
           {loadingCategories && categories.length === 0 ? (
             <LoadingSkeleton />
           ) : error && categories.length === 0 ? (
             <ErrorState message={error} onRetry={() => fetchCategories()} />
           ) : (
-            <div className="grid gap-4 data-[density=compact]:gap-3 md:grid-cols-2 xl:grid-cols-3">
+            <div
+              className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 xl:gap-6 2xl:gap-7 data-[density=compact]:gap-4"
+              data-density={density}
+            >
               {categories.map((category) => (
                 <CategoryCard key={category.id} category={category} />
               ))}
@@ -60,7 +66,7 @@ const Forum = () => {
           )}
         </section>
 
-        <section className="space-y-4" data-density={density}>
+        <section className="space-y-5 data-[density=compact]:space-y-4" data-density={density}>
           <TabsBar onChange={(value) => fetchThreads({ sort: value as typeof activeTab })} />
           {loadingThreads && threads.length === 0 ? (
             <LoadingSkeleton />
@@ -69,7 +75,10 @@ const Forum = () => {
           ) : threads.length === 0 ? (
             <EmptyState />
           ) : (
-            <div className="divide-y divide-border/60 overflow-hidden rounded-3xl border border-border/60 bg-card/60 backdrop-blur supports-[backdrop-filter]:bg-card/50">
+            <div
+              className="flex flex-col divide-y divide-border/60 space-y-4 rounded-3xl border border-border/60 bg-background/60 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] supports-[backdrop-filter]:bg-background/70 md:space-y-5 2xl:space-y-6 data-[density=compact]:space-y-3 md:data-[density=compact]:space-y-4"
+              data-density={density}
+            >
               {threads.map((thread) => (
                 <ThreadItem key={thread.id} thread={thread} />
               ))}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,6 +24,10 @@
   --input: 217 33% 18%;
   --ring: 184 100% 50%;
   --radius: 0.95rem;
+  --step-0: clamp(0.95rem, 0.25vw + 0.9rem, 1.05rem);
+  --step-1: clamp(1.15rem, 0.5vw + 1rem, 1.35rem);
+  --step-2: clamp(1.35rem, 0.7vw + 1.1rem, 1.6rem);
+  --step-3: clamp(1.6rem, 1vw + 1.2rem, 1.9rem);
 }
 
 .light {
@@ -52,10 +56,20 @@
 body {
   @apply bg-background text-foreground antialiased;
   min-height: 100vh;
+  font-size: var(--step-0);
+  line-height: 1.65;
+  letter-spacing: 0.01em;
   background-image: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.2), transparent 45%),
     radial-gradient(circle at 80% 0%, rgba(0, 224, 255, 0.2), transparent 55%),
     radial-gradient(circle at 50% 100%, rgba(124, 58, 237, 0.16), transparent 50%);
   background-attachment: fixed;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  letter-spacing: -0.015em;
 }
 
 ::selection {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,9 @@ const config: Config = {
       }
     },
     extend: {
+      screens: {
+        "3xl": "1920px"
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
## Summary
- introduce a 3xl breakpoint and fluid type scale to support wider screens
- rebuild the forum shell with a centered three-column grid, sticky sidebars, and density-aware spacing
- refresh sidebar, card, and chat dock components with larger paddings, glass backgrounds, and updated typography

## Testing
- `npm run build` *(fails: missing @tsparticles/react, @tsparticles/slim, @tsparticles/engine type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68d80c511204832781efe3cba570b51d