### PR TITLE
Refine forum category explorer layout

### DIFF
--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -1,16 +1,27 @@
+import type { InputHTMLAttributes } from "react";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils/cn";
 
-interface SearchBarProps {
-  placeholder?: string;
-  className?: string;
+interface SearchBarProps extends InputHTMLAttributes<HTMLInputElement> {
+  inputClassName?: string;
 }
 
-const SearchBar = ({ placeholder = "Suche nach Threads, Spielern, Tags", className }: SearchBarProps) => (
+const SearchBar = ({
+  placeholder = "Suche nach Threads, Spielern, Tags",
+  className,
+  inputClassName,
+  "aria-label": ariaLabel,
+  ...props
+}: SearchBarProps) => (
   <div className={cn("relative w-full max-w-xl", className)}>
-    <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-    <Input className="pl-9" placeholder={placeholder} aria-label="Forum durchsuchen" />
+    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+    <Input
+      {...props}
+      placeholder={placeholder}
+      aria-label={ariaLabel ?? placeholder}
+      className={cn("pl-9", inputClassName)}
+    />
   </div>
 );
 

--- a/src/components/forum/CategoryCard.tsx
+++ b/src/components/forum/CategoryCard.tsx
@@ -1,45 +1,86 @@
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
-import { hoverLift } from "@/lib/animations/framer";
 import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
 import type { Category } from "@/lib/api/types";
 import type { LucideIcon } from "lucide-react";
-import { Crosshair, Swords, Shield, Sparkles } from "lucide-react";
+import {
+  Brain,
+  Crosshair,
+  Gamepad2,
+  HeartPulse,
+  Joystick,
+  Palette,
+  Rocket,
+  Shield,
+  Smartphone,
+  Sparkles,
+  Swords,
+  Users
+} from "lucide-react";
 import { useUiStore } from "@/store/uiStore";
+import SubcategoryCollapse from "@/components/forum/SubcategoryCollapse";
 
 const iconMap: Record<string, LucideIcon> = {
   crosshair: Crosshair,
   swords: Swords,
   shield: Shield,
-  sparkles: Sparkles
+  sparkles: Sparkles,
+  rocket: Rocket,
+  brain: Brain,
+  palette: Palette,
+  "gamepad-2": Gamepad2,
+  smartphone: Smartphone,
+  joystick: Joystick,
+  users: Users,
+  "heart-pulse": HeartPulse
 };
+
+const MotionLink = motion(Link);
 
 const CategoryCard = ({ category }: { category: Category }) => {
   const Icon = iconMap[category.icon ?? "sparkles"] ?? Sparkles;
   const density = useUiStore((state) => state.density);
 
   return (
-    <motion.div variants={hoverLift} initial="rest" whileHover="hover" animate="rest" className="h-full">
-      <Link
-        to={`/forum/${category.id}`}
-        data-density={density}
-        className="flex h-full flex-col justify-between gap-6 rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] transition hover:border-primary/60 supports-[backdrop-filter]:bg-background/70 md:p-6 2xl:p-7 data-[density=compact]:gap-4 data-[density=compact]:rounded-2xl data-[density=compact]:p-4"
-      >
-        <div className="space-y-4">
-          <span className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-primary/15 text-primary">
-            <Icon className="h-6 w-6" />
-          </span>
-          <div className="space-y-2">
-            <h3 className="text-xl font-semibold tracking-tight text-foreground 2xl:text-[1.35rem]">{category.name}</h3>
-            <p className="text-sm text-muted-foreground leading-relaxed">{category.description}</p>
+    <MotionLink
+      to={`/forum/${category.id}`}
+      whileHover={{ y: -2, scale: 1.01 }}
+      transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+      className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      data-density={density}
+    >
+      <Card className="relative h-full overflow-hidden rounded-2xl border-border/60 bg-card/80 shadow-[0_20px_45px_-28px_rgba(0,0,0,0.55)] transition-colors hover:border-primary/50 supports-[backdrop-filter]:bg-card/75">
+        <div
+          className="flex min-h-[180px] flex-col p-5 md:p-6 2xl:p-7 data-[density=compact]:p-4"
+          data-density={density}
+        >
+          <div className="flex items-center gap-3">
+            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <Icon className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <h3 className="text-lg font-semibold tracking-tight md:text-xl">{category.name}</h3>
+          </div>
+
+          {category.description ? (
+            <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+              {category.description}
+            </p>
+          ) : null}
+
+          {category.subcategories?.length ? <SubcategoryCollapse subs={category.subcategories} /> : null}
+
+          <div className="mt-auto flex items-center gap-3 pt-4 text-xs text-muted-foreground md:text-sm">
+            <Badge variant="secondary" className="rounded-full px-2.5 py-0.5">
+              {category.threadCount} Threads
+            </Badge>
+            <Badge variant="secondary" className="rounded-full px-2.5 py-0.5">
+              {category.postCount} Posts
+            </Badge>
           </div>
         </div>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Badge variant="accent">{category.threadCount} Threads</Badge>
-          <span>{category.postCount} Posts</span>
-        </div>
-      </Link>
-    </motion.div>
+      </Card>
+    </MotionLink>
   );
 };
 

--- a/src/components/forum/SubcategoryCollapse.tsx
+++ b/src/components/forum/SubcategoryCollapse.tsx
@@ -1,0 +1,59 @@
+import { useId, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import type { SubCategory } from "@/lib/api/types";
+
+interface SubcategoryCollapseProps {
+  subs: SubCategory[];
+}
+
+const transition = { duration: 0.28, ease: [0.25, 0.8, 0.25, 1] };
+
+const SubcategoryCollapse = ({ subs }: SubcategoryCollapseProps) => {
+  const [open, setOpen] = useState(false);
+  const collapseId = useId();
+  const visibleSubs = useMemo(() => (open ? subs : subs.slice(0, 6)), [open, subs]);
+  const showToggle = subs.length > 6;
+
+  return (
+    <div className="mt-3">
+      <div className="relative">
+        <motion.div
+          layout
+          initial={false}
+          animate={{ height: !showToggle || open ? "auto" : 96 }}
+          transition={transition}
+          className={showToggle ? "overflow-hidden" : undefined}
+          id={collapseId}
+        >
+          <div className="flex flex-wrap gap-2">
+            {visibleSubs.map((sub) => (
+              <span
+                key={`sub_${sub.id}`}
+                className="rounded-full bg-secondary/60 px-2.5 py-1 text-xs"
+                title={`${sub.threadCount} Threads`}
+              >
+                {sub.name}
+              </span>
+            ))}
+          </div>
+        </motion.div>
+        {showToggle && !open ? (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-card via-card/80 to-transparent" />
+        ) : null}
+      </div>
+      {showToggle ? (
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="mt-2 text-xs text-primary hover:underline"
+          aria-expanded={open}
+          aria-controls={collapseId}
+        >
+          {open ? "Weniger anzeigen" : `Mehr anzeigen (${subs.length - 6})`}
+        </button>
+      ) : null}
+    </div>
+  );
+};
+
+export default SubcategoryCollapse;

--- a/src/lib/api/mockApi.ts
+++ b/src/lib/api/mockApi.ts
@@ -2,6 +2,7 @@ import { nanoid } from "nanoid";
 import { newId } from "../utils/id";
 import type {
   Category,
+  CategoryFilter,
   ChatMessage,
   PaginatedResponse,
   Post,
@@ -56,7 +57,16 @@ const categories: Category[] = [
     description: "Taktische Shooter, Loadouts & Aim-Training",
     icon: "crosshair",
     threadCount: 128,
-    postCount: 982
+    postCount: 982,
+    subcategories: [
+      { id: "sub-1", name: "Aim-Labs", threadCount: 32 },
+      { id: "sub-2", name: "Loadouts", threadCount: 44 },
+      { id: "sub-3", name: "Scrims", threadCount: 21 },
+      { id: "sub-4", name: "Ranked", threadCount: 18 },
+      { id: "sub-5", name: "Controller", threadCount: 9 },
+      { id: "sub-6", name: "LAN-Events", threadCount: 4 },
+      { id: "sub-7", name: "Coaching", threadCount: 12 }
+    ]
   },
   {
     id: "cat-2",
@@ -65,7 +75,13 @@ const categories: Category[] = [
     description: "Storytelling, Builds & Theorycrafting",
     icon: "swords",
     threadCount: 96,
-    postCount: 804
+    postCount: 804,
+    subcategories: [
+      { id: "sub-8", name: "Lore", threadCount: 28 },
+      { id: "sub-9", name: "Builds", threadCount: 36 },
+      { id: "sub-10", name: "Mods", threadCount: 17 },
+      { id: "sub-11", name: "Speedruns", threadCount: 11 }
+    ]
   },
   {
     id: "cat-3",
@@ -74,7 +90,13 @@ const categories: Category[] = [
     description: "Drafts, Meta-Analyse & Turniere",
     icon: "shield",
     threadCount: 75,
-    postCount: 612
+    postCount: 612,
+    subcategories: [
+      { id: "sub-12", name: "Patchnotes", threadCount: 22 },
+      { id: "sub-13", name: "Champion-Guides", threadCount: 18 },
+      { id: "sub-14", name: "Drafting", threadCount: 14 },
+      { id: "sub-15", name: "Esports", threadCount: 16 }
+    ]
   },
   {
     id: "cat-4",
@@ -83,9 +105,152 @@ const categories: Category[] = [
     description: "Hidden Gems & Game Dev Insights",
     icon: "sparkles",
     threadCount: 54,
-    postCount: 301
+    postCount: 301,
+    subcategories: [
+      { id: "sub-16", name: "Pixel Art", threadCount: 12 },
+      { id: "sub-17", name: "Solo Dev", threadCount: 9 },
+      { id: "sub-18", name: "Narrative", threadCount: 7 },
+      { id: "sub-19", name: "Soundtracks", threadCount: 6 }
+    ]
+  },
+  {
+    id: "cat-5",
+    slug: "sim",
+    name: "Sim Orbit",
+    description: "Space- & Vehicle-Sims, Cockpits & Telemetrie",
+    icon: "rocket",
+    threadCount: 82,
+    postCount: 540,
+    subcategories: [
+      { id: "sub-20", name: "Flight Sims", threadCount: 24 },
+      { id: "sub-21", name: "Racing", threadCount: 20 },
+      { id: "sub-22", name: "Hardware", threadCount: 16 },
+      { id: "sub-23", name: "VR", threadCount: 12 }
+    ]
+  },
+  {
+    id: "cat-6",
+    slug: "strategy",
+    name: "Strategium",
+    description: "4X, RTS & Taktik-Highlights im Deep-Dive",
+    icon: "brain",
+    threadCount: 91,
+    postCount: 688,
+    subcategories: [
+      { id: "sub-24", name: "Build Orders", threadCount: 21 },
+      { id: "sub-25", name: "Turniere", threadCount: 13 },
+      { id: "sub-26", name: "Wargames", threadCount: 9 },
+      { id: "sub-27", name: "Deckbau", threadCount: 10 }
+    ]
+  },
+  {
+    id: "cat-7",
+    slug: "creative",
+    name: "Creative Forge",
+    description: "Modding, Asset-Sharing & Tooling",
+    icon: "palette",
+    threadCount: 48,
+    postCount: 274,
+    subcategories: [
+      { id: "sub-28", name: "Blender", threadCount: 14 },
+      { id: "sub-29", name: "Unreal", threadCount: 11 },
+      { id: "sub-30", name: "Unity", threadCount: 9 },
+      { id: "sub-31", name: "Shaders", threadCount: 6 },
+      { id: "sub-32", name: "Concept Art", threadCount: 8 }
+    ]
+  },
+  {
+    id: "cat-8",
+    slug: "fighting",
+    name: "Fight Lab",
+    description: "Frame Data, Tech & Match-Ups",
+    icon: "gamepad-2",
+    threadCount: 58,
+    postCount: 402,
+    subcategories: [
+      { id: "sub-33", name: "Combo Guides", threadCount: 19 },
+      { id: "sub-34", name: "Netcode", threadCount: 8 },
+      { id: "sub-35", name: "Events", threadCount: 12 },
+      { id: "sub-36", name: "Tier Lists", threadCount: 11 }
+    ]
+  },
+  {
+    id: "cat-9",
+    slug: "mobile",
+    name: "Pocket Realm",
+    description: "Mobile Games, Touch-Optimierungen & Cloud Play",
+    icon: "smartphone",
+    threadCount: 67,
+    postCount: 358,
+    subcategories: [
+      { id: "sub-37", name: "Gacha", threadCount: 15 },
+      { id: "sub-38", name: "Controllers", threadCount: 10 },
+      { id: "sub-39", name: "Cloud", threadCount: 14 },
+      { id: "sub-40", name: "Indie", threadCount: 8 }
+    ]
+  },
+  {
+    id: "cat-10",
+    slug: "retro",
+    name: "Retro Vault",
+    description: "Speedruns, Preservation & CRT-Setups",
+    icon: "joystick",
+    threadCount: 43,
+    postCount: 245,
+    subcategories: [
+      { id: "sub-41", name: "Emulation", threadCount: 16 },
+      { id: "sub-42", name: "Hardware", threadCount: 12 },
+      { id: "sub-43", name: "Records", threadCount: 9 }
+    ]
+  },
+  {
+    id: "cat-11",
+    slug: "coop",
+    name: "Co-Op Collective",
+    description: "Partyfinder, Clan-Support & Crossplay",
+    icon: "users",
+    threadCount: 62,
+    postCount: 331,
+    subcategories: [
+      { id: "sub-44", name: "LFG", threadCount: 20 },
+      { id: "sub-45", name: "Crossplay", threadCount: 12 },
+      { id: "sub-46", name: "Clans", threadCount: 14 },
+      { id: "sub-47", name: "Events", threadCount: 10 }
+    ]
+  },
+  {
+    id: "cat-12",
+    slug: "wellbeing",
+    name: "Player Balance",
+    description: "Performance, Ergonomie & Mental Game",
+    icon: "heart-pulse",
+    threadCount: 37,
+    postCount: 214,
+    subcategories: [
+      { id: "sub-48", name: "Ergonomie", threadCount: 11 },
+      { id: "sub-49", name: "Mindset", threadCount: 9 },
+      { id: "sub-50", name: "Workout", threadCount: 8 },
+      { id: "sub-51", name: "Nutrition", threadCount: 6 }
+    ]
   }
 ];
+
+const categoryMeta: Record<string, { createdAt: number; hasNew: boolean; tag: string }> = {
+  "cat-1": { createdAt: Date.parse("2024-06-12"), hasNew: true, tag: "Shooter" },
+  "cat-2": { createdAt: Date.parse("2024-05-30"), hasNew: true, tag: "RPG" },
+  "cat-3": { createdAt: Date.parse("2024-04-18"), hasNew: false, tag: "MOBA" },
+  "cat-4": { createdAt: Date.parse("2024-03-11"), hasNew: true, tag: "Indie" },
+  "cat-5": { createdAt: Date.parse("2024-06-02"), hasNew: false, tag: "Simulation" },
+  "cat-6": { createdAt: Date.parse("2024-02-22"), hasNew: true, tag: "Strategy" },
+  "cat-7": { createdAt: Date.parse("2024-01-12"), hasNew: false, tag: "Creative" },
+  "cat-8": { createdAt: Date.parse("2024-05-05"), hasNew: true, tag: "Fighting" },
+  "cat-9": { createdAt: Date.parse("2024-04-01"), hasNew: true, tag: "Mobile" },
+  "cat-10": { createdAt: Date.parse("2023-12-18"), hasNew: false, tag: "Retro" },
+  "cat-11": { createdAt: Date.parse("2024-03-30"), hasNew: true, tag: "Co-Op" },
+  "cat-12": { createdAt: Date.parse("2024-02-10"), hasNew: false, tag: "Wellbeing" }
+};
+
+const categoryGenres = Array.from(new Set(Object.values(categoryMeta).map((meta) => meta.tag))).sort();
 
 const threadSeeds: ThreadWithMeta[] = Array.from({ length: 24 }).map((_, idx) => {
   const category = categories[idx % categories.length];
@@ -161,10 +326,62 @@ export const mockApi = {
     maybeFail();
     return { ...stats, usersOnline: stats.usersOnline + Math.round(Math.random() * 12 - 6) };
   },
-  async getCategories(): Promise<Category[]> {
+  async getCategories(filter: CategoryFilter = {}): Promise<PaginatedResponse<Category>> {
     await wait();
     maybeFail();
-    return categories;
+
+    const { q, sort = "name", onlyNew, tag, page = 1, pageSize = 12 } = filter;
+
+    const normalizedQuery = q?.trim().toLowerCase();
+
+    let filtered = categories.slice();
+
+    if (normalizedQuery) {
+      filtered = filtered.filter((category) => {
+        const matchesCategory =
+          category.name.toLowerCase().includes(normalizedQuery) ||
+          category.description?.toLowerCase().includes(normalizedQuery);
+        const matchesSub = category.subcategories?.some((sub) =>
+          sub.name.toLowerCase().includes(normalizedQuery)
+        );
+        return matchesCategory || matchesSub;
+      });
+    }
+
+    if (onlyNew) {
+      filtered = filtered.filter((category) => categoryMeta[category.id]?.hasNew);
+    }
+
+    if (tag) {
+      filtered = filtered.filter((category) => categoryMeta[category.id]?.tag === tag);
+    }
+
+    const sorted = filtered.sort((a, b) => {
+      switch (sort) {
+        case "threads":
+          return b.threadCount - a.threadCount;
+        case "posts":
+          return b.postCount - a.postCount;
+        case "new":
+          return (categoryMeta[b.id]?.createdAt ?? 0) - (categoryMeta[a.id]?.createdAt ?? 0);
+        case "name":
+        default:
+          return a.name.localeCompare(b.name, "de-DE");
+      }
+    });
+
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+
+    return {
+      data: sorted.slice(start, end),
+      page,
+      pageSize,
+      total: sorted.length
+    } satisfies PaginatedResponse<Category>;
+  },
+  getCategoryGenres(): string[] {
+    return categoryGenres;
   },
   async getThreads(filter: ThreadFilter = {}): Promise<PaginatedResponse<ThreadWithMeta>> {
     await wait();

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -7,6 +7,12 @@ export interface User {
   createdAt: string;
 }
 
+export interface SubCategory {
+  id: ID;
+  name: string;
+  threadCount: number;
+}
+
 export interface Category {
   id: ID;
   slug: string;
@@ -15,6 +21,16 @@ export interface Category {
   icon?: string;
   threadCount: number;
   postCount: number;
+  subcategories?: SubCategory[];
+}
+
+export interface CategoryFilter {
+  q?: string;
+  sort?: "name" | "threads" | "posts" | "new";
+  onlyNew?: boolean;
+  tag?: string;
+  page?: number;
+  pageSize?: number;
 }
 
 export interface Thread {

--- a/src/routes/Forum.tsx
+++ b/src/routes/Forum.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForumStore } from "@/store/forumStore";
 import { useUiStore } from "@/store/uiStore";
 import PageTransition from "@/components/layout/PageTransition";
@@ -9,17 +9,135 @@ import LoadingSkeleton from "@/components/common/LoadingSkeleton";
 import ErrorState from "@/components/common/ErrorState";
 import EmptyState from "@/components/forum/EmptyState";
 import { Button } from "@/components/ui/button";
+import SearchBar from "@/components/common/SearchBar";
 import { MessageSquarePlus } from "lucide-react";
+import { Loader2, ChevronDown, Check, SlidersHorizontal, Sparkles } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
+import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
+import { cn } from "@/lib/utils/cn";
+import type { CategoryFilter } from "@/lib/api/types";
+
+const CATEGORY_SORT_OPTIONS: Array<{ value: NonNullable<CategoryFilter["sort"]>; label: string }> = [
+  { value: "name", label: "Name A–Z" },
+  { value: "threads", label: "Meiste Threads" },
+  { value: "posts", label: "Meiste Posts" },
+  { value: "new", label: "Neu hinzugefügt" }
+];
+
+const gridVariants = {
+  hidden: {},
+  show: {
+    transition: {
+      staggerChildren: 0.05,
+      delayChildren: 0.04
+    }
+  }
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.32, ease: [0.22, 1, 0.36, 1] } }
+};
 
 const Forum = () => {
   const navigate = useNavigate();
   const activeTab = useUiStore((state) => state.activeTab);
-  const { categories, threads, loadingCategories, loadingThreads, error, fetchCategories, fetchThreads } = useForumStore();
+  const {
+    categories,
+    categoryFilters,
+    categoryTags,
+    totalCategories,
+    hasMoreCategories,
+    threads,
+    loadingCategories,
+    loadingMoreCategories,
+    loadingThreads,
+    error,
+    fetchCategories,
+    fetchThreads
+  } = useForumStore((state) => ({
+    categories: state.categories,
+    categoryFilters: state.categoryFilters,
+    categoryTags: state.categoryTags,
+    totalCategories: state.totalCategories,
+    hasMoreCategories: state.hasMoreCategories,
+    threads: state.threads,
+    loadingCategories: state.loadingCategories,
+    loadingMoreCategories: state.loadingMoreCategories,
+    loadingThreads: state.loadingThreads,
+    error: state.error,
+    fetchCategories: state.fetchCategories,
+    fetchThreads: state.fetchThreads
+  }));
+
+  const [searchTerm, setSearchTerm] = useState(categoryFilters.q);
+
+  useEffect(() => {
+    setSearchTerm(categoryFilters.q);
+  }, [categoryFilters.q]);
 
   useEffect(() => {
     void fetchCategories();
   }, [fetchCategories]);
+
+  useEffect(() => {
+    if (searchTerm === categoryFilters.q) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      void fetchCategories({ q: searchTerm, page: 1 });
+    }, 280);
+
+    return () => clearTimeout(timeout);
+  }, [searchTerm, categoryFilters.q, fetchCategories]);
+
+  const handleSortChange = useCallback(
+    (value: NonNullable<CategoryFilter["sort"]>) => {
+      if (value === categoryFilters.sort) {
+        return;
+      }
+      void fetchCategories({ sort: value, page: 1 });
+    },
+    [categoryFilters.sort, fetchCategories]
+  );
+
+  const handleToggleOnlyNew = useCallback(() => {
+    void fetchCategories({ onlyNew: !categoryFilters.onlyNew, page: 1 });
+  }, [categoryFilters.onlyNew, fetchCategories]);
+
+  const handleTagSelect = useCallback(
+    (tag?: string) => {
+      if (tag === categoryFilters.tag) {
+        return;
+      }
+      void fetchCategories({ tag, page: 1 });
+    },
+    [categoryFilters.tag, fetchCategories]
+  );
+
+  const handleLoadMoreCategories = useCallback(() => {
+    void fetchCategories({ append: true });
+  }, [fetchCategories]);
+
+  const activeSortLabel = useMemo(
+    () => CATEGORY_SORT_OPTIONS.find((option) => option.value === categoryFilters.sort)?.label ?? "Sortierung",
+    [categoryFilters.sort]
+  );
+
+  const activeTagLabel = categoryFilters.tag ?? "Alle Genres/Tags";
+  const remainingCategories = Math.max(totalCategories - categories.length, 0);
+  const isInitialCategoryLoading = loadingCategories && categories.length === 0;
+  const categoryError = error && categories.length === 0;
+  const isCategoryEmpty = !loadingCategories && categories.length === 0 && !error;
 
   useEffect(() => {
     void fetchThreads({ sort: activeTab });
@@ -48,22 +166,162 @@ const Forum = () => {
           </div>
         </div>
 
-        <section className="space-y-5 data-[density=compact]:space-y-4" data-density={density}>
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</h2>
-          {loadingCategories && categories.length === 0 ? (
-            <LoadingSkeleton />
-          ) : error && categories.length === 0 ? (
-            <ErrorState message={error} onRetry={() => fetchCategories()} />
-          ) : (
-            <div
-              className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 xl:gap-6 2xl:gap-7 data-[density=compact]:gap-4"
-              data-density={density}
-            >
-              {categories.map((category) => (
-                <CategoryCard key={category.id} category={category} />
-              ))}
+        <section className="mb-6 mt-6 md:mb-8 md:mt-8 2xl:mt-10" data-density={density}>
+          <header className="sticky top-20 z-20 -mx-4 border-b border-border/60 bg-background/60 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/70 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8 2xl:-mx-10 2xl:px-10">
+            <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between 2xl:max-w-[1160px]">
+              <div className="flex w-full flex-col gap-2 sm:max-w-md">
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</span>
+                <SearchBar
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                  placeholder="Suche Kategorien/Subkategorien…"
+                  className="w-full"
+                  inputClassName="h-10 rounded-xl"
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-9 rounded-full px-4 text-xs font-medium"
+                    >
+                      <span className="mr-2 inline-flex items-center gap-1">
+                        <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+                        {activeSortLabel}
+                      </span>
+                      <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-[12rem]">
+                    <DropdownMenuLabel>Sortieren nach</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {CATEGORY_SORT_OPTIONS.map((option) => (
+                      <DropdownMenuItem
+                        key={option.value}
+                        onSelect={() => handleSortChange(option.value)}
+                        className={cn(
+                          "flex items-center justify-between gap-4 text-sm",
+                          categoryFilters.sort === option.value ? "text-primary" : undefined
+                        )}
+                      >
+                        {option.label}
+                        {categoryFilters.sort === option.value ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-9 rounded-full px-4 text-xs font-medium"
+                    >
+                      <span className="mr-2">{activeTagLabel}</span>
+                      <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="min-w-[12rem]">
+                    <DropdownMenuLabel>Genre / Tag</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onSelect={() => handleTagSelect(undefined)}
+                      className={cn(
+                        "flex items-center justify-between gap-4 text-sm",
+                        !categoryFilters.tag ? "text-primary" : undefined
+                      )}
+                    >
+                      Alle Genres/Tags
+                      {!categoryFilters.tag ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
+                    </DropdownMenuItem>
+                    {categoryTags.map((tag) => (
+                      <DropdownMenuItem
+                        key={tag}
+                        onSelect={() => handleTagSelect(tag)}
+                        className={cn(
+                          "flex items-center justify-between gap-4 text-sm",
+                          categoryFilters.tag === tag ? "text-primary" : undefined
+                        )}
+                      >
+                        {tag}
+                        {categoryFilters.tag === tag ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleToggleOnlyNew}
+                  aria-pressed={categoryFilters.onlyNew}
+                  className={cn(
+                    "h-9 rounded-full px-4 text-xs font-medium transition-colors",
+                    categoryFilters.onlyNew
+                      ? "border-primary/50 bg-primary/10 text-primary hover:bg-primary/15"
+                      : "hover:bg-muted/60"
+                  )}
+                >
+                  <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                  Nur mit neuen Beiträgen
+                </Button>
+              </div>
             </div>
-          )}
+          </header>
+
+          <div className="mx-auto w-full max-w-[1040px] px-4 pt-4 sm:px-6 lg:px-8 2xl:max-w-[1160px] 2xl:px-10">
+            {isInitialCategoryLoading ? (
+              <LoadingSkeleton />
+            ) : categoryError ? (
+              <ErrorState message={error ?? "Es ist ein Fehler aufgetreten."} onRetry={() => fetchCategories()} />
+            ) : isCategoryEmpty ? (
+              <div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-10 text-center text-sm text-muted-foreground">
+                Keine Kategorien gefunden. Versuche es mit anderen Filtern.
+              </div>
+            ) : (
+              <>
+                <motion.div
+                  variants={gridVariants}
+                  initial="hidden"
+                  animate="show"
+                  className="grid [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))] gap-5 xl:gap-6 2xl:gap-7"
+                >
+                  {categories.map((category) => (
+                    <motion.div key={`cat_${category.id}`} variants={cardVariants}>
+                      <CategoryCard category={category} />
+                    </motion.div>
+                  ))}
+                </motion.div>
+
+                {hasMoreCategories ? (
+                  <div className="mt-6 flex justify-center">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="rounded-full px-6"
+                      disabled={loadingMoreCategories}
+                      onClick={handleLoadMoreCategories}
+                    >
+                      {loadingMoreCategories ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                          Lädt weitere Kategorien…
+                        </>
+                      ) : remainingCategories > 0 ? (
+                        `Mehr laden (${remainingCategories})`
+                      ) : (
+                        "Mehr laden"
+                      )}
+                    </Button>
+                  </div>
+                ) : null}
+              </>
+            )}
+          </div>
         </section>
 
         <section className="space-y-5 data-[density=compact]:space-y-4" data-density={density}>

--- a/src/store/forumStore.ts
+++ b/src/store/forumStore.ts
@@ -1,36 +1,117 @@
 import { create } from "zustand";
 import { mockApi } from "@/lib/api/mockApi";
-import type { Category, PaginatedResponse, ThreadFilter, ThreadWithMeta } from "@/lib/api/types";
+import type {
+  Category,
+  CategoryFilter,
+  PaginatedResponse,
+  ThreadFilter,
+  ThreadWithMeta
+} from "@/lib/api/types";
+
+interface CategoryQueryState {
+  q: string;
+  sort: NonNullable<CategoryFilter["sort"]>;
+  onlyNew: boolean;
+  tag?: string;
+  page: number;
+  pageSize: number;
+}
 
 interface ForumState {
   categories: Category[];
+  categoryTags: string[];
+  categoryFilters: CategoryQueryState;
+  hasMoreCategories: boolean;
+  totalCategories: number;
   threads: ThreadWithMeta[];
   totalThreads: number;
   loadingCategories: boolean;
+  loadingMoreCategories: boolean;
   loadingThreads: boolean;
   error?: string;
   selectedCategory?: string;
-  fetchCategories: () => Promise<void>;
+  fetchCategories: (
+    filters?: CategoryFilter & {
+      append?: boolean;
+    }
+  ) => Promise<void>;
   fetchThreads: (filter?: ThreadFilter) => Promise<void>;
   createThread: (
     payload: Pick<ThreadWithMeta, "categoryId" | "title" | "tags"> & { body: string; authorId: string }
   ) => Promise<void>;
 }
 
+const dedupeCategories = (items: Category[]) => {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) {
+      return false;
+    }
+    seen.add(item.id);
+    return true;
+  });
+};
+
+const defaultCategoryFilters: CategoryQueryState = {
+  q: "",
+  sort: "name",
+  onlyNew: false,
+  tag: undefined,
+  page: 1,
+  pageSize: 12
+};
+
 export const useForumStore = create<ForumState>((set, get) => ({
   categories: [],
+  categoryTags: mockApi.getCategoryGenres(),
+  categoryFilters: { ...defaultCategoryFilters },
+  hasMoreCategories: false,
+  totalCategories: 0,
   threads: [],
   totalThreads: 0,
   loadingCategories: false,
+  loadingMoreCategories: false,
   loadingThreads: false,
   selectedCategory: undefined,
-  async fetchCategories() {
-    set({ loadingCategories: true, error: undefined });
+  async fetchCategories(filters) {
+    const append = filters?.append ?? false;
+    const currentFilters = get().categoryFilters;
+    const nextFilters: CategoryQueryState = {
+      q: filters?.q ?? currentFilters.q,
+      sort: filters?.sort ?? currentFilters.sort,
+      onlyNew: filters?.onlyNew ?? currentFilters.onlyNew,
+      tag: filters?.tag !== undefined ? filters.tag : currentFilters.tag,
+      page: append ? filters?.page ?? currentFilters.page + 1 : filters?.page ?? 1,
+      pageSize: filters?.pageSize ?? currentFilters.pageSize
+    };
+
+    set({
+      loadingCategories: !append,
+      loadingMoreCategories: append,
+      error: undefined
+    });
+
     try {
-      const data = await mockApi.getCategories();
-      set({ categories: data, loadingCategories: false });
+      const response = await mockApi.getCategories(nextFilters);
+      set((state) => {
+        const merged = append ? dedupeCategories([...state.categories, ...response.data]) : response.data;
+        const hasMore = response.page * response.pageSize < response.total;
+        return {
+          categories: merged,
+          categoryFilters: nextFilters,
+          hasMoreCategories: hasMore,
+          totalCategories: response.total,
+          loadingCategories: false,
+          loadingMoreCategories: false,
+          error: undefined
+        };
+      });
     } catch (error) {
-      set({ loadingCategories: false, error: error instanceof Error ? error.message : String(error) });
+      set({
+        loadingCategories: false,
+        loadingMoreCategories: false,
+        error: error instanceof Error ? error.message : String(error)
+      });
     }
   },
   async fetchThreads(filter) {


### PR DESCRIPTION
## Summary
- redesign the forum category section with a sticky toolbar, responsive auto-fit grid, and animated cards
- add subcategory pill collapse support, category filtering, sorting, and pagination backed by updated store state
- extend the mock API and types with subcategory metadata and filtered category queries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8115a053c8327ac2bd698e00f85de