### PR TITLE
Add forums overview with chatbox and board sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Forum from "@/routes/Forum";
 import Category from "@/routes/Category";
 import Thread from "@/routes/Thread";
 import CreatePost from "@/routes/CreatePost";
+import Forums from "@/routes/Forums";
 import Login from "@/routes/Auth/Login";
 import Register from "@/routes/Auth/Register";
 import { useUiStore } from "@/store/uiStore";
@@ -52,6 +53,7 @@ const App = () => {
         <Routes location={location} key={location.pathname}>
           <Route path="/" element={<Landing />} />
           <Route path="/forum" element={<Forum />} />
+          <Route path="/forums" element={<Forums />} />
           <Route path="/forum/:categoryId" element={<Category />} />
           <Route path="/thread/:threadId" element={<Thread />} />
           <Route path="/create" element={<CreatePost />} />

--- a/src/components/chat/Chatbox.tsx
+++ b/src/components/chat/Chatbox.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from "react";
+import { Smile, MoreHorizontal, Info, Send } from "lucide-react";
+import { nanoid } from "nanoid";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useChatStore } from "@/store/chatStore";
+import { mockApi } from "@/lib/api/mockApi";
+import type { ChatMessage } from "@/lib/api/types";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit"
+});
+
+const Chatbox = () => {
+  const messages = useChatStore((state) => state.ordered());
+  const addMessage = useChatStore((state) => state.addMessage);
+  const addMessages = useChatStore((state) => state.addMessages);
+  const [input, setInput] = useState("");
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const seededRef = useRef(false);
+
+  useEffect(() => {
+    if (seededRef.current) return;
+    seededRef.current = true;
+    void mockApi.getSystemMessages().then((seed) => {
+      addMessages(seed);
+    });
+  }, [addMessages]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length]);
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    const message: ChatMessage = {
+      id: nanoid(),
+      text: trimmed,
+      createdAt: new Date().toISOString(),
+      author: {
+        id: "you",
+        name: "You",
+        avatarUrl: "https://i.pravatar.cc/150?img=1"
+      }
+    };
+    addMessage(message);
+    setInput("");
+  };
+
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card/80 shadow-sm backdrop-blur">
+      <div className="flex items-center justify-between border-b border-border/60 px-4 py-3 text-sm font-medium md:px-5">
+        <span>Community Chat</span>
+        <div className="flex items-center gap-1">
+          <Button variant="ghost" size="icon" className="size-8 rounded-full" aria-label="Informationen">
+            <Info className="h-4 w-4" />
+          </Button>
+          <Button variant="ghost" size="icon" className="size-8 rounded-full" aria-label="Weitere Aktionen">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+      <ScrollArea className="h-[260px] md:h-[320px]">
+        <div className="space-y-2 py-2">
+          {messages.map((message) => (
+            <div key={message.id} className="flex gap-3 px-4 py-3">
+              {message.system ? (
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/20 text-sm font-semibold text-primary">
+                  ★
+                </div>
+              ) : (
+                <Avatar className="h-9 w-9">
+                  <AvatarImage src={message.author?.avatarUrl} alt={message.author?.name} />
+                  <AvatarFallback>{message.author?.name?.slice(0, 2) ?? "NL"}</AvatarFallback>
+                </Avatar>
+              )}
+              <div className="flex-1 space-y-1">
+                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">{message.author?.name ?? "System"}</span>
+                  <span>{timeFormatter.format(new Date(message.createdAt))}</span>
+                </div>
+                <p className="text-sm text-muted-foreground">{message.text}</p>
+              </div>
+            </div>
+          ))}
+          <div ref={bottomRef} />
+        </div>
+      </ScrollArea>
+      <div className="flex items-center gap-2 border-t border-border/60 px-4 py-3 md:px-5">
+        <Textarea
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          placeholder="Share a quick update with the squad..."
+          className="min-h-[40px] flex-1 resize-none bg-transparent"
+          rows={2}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              handleSend();
+            }
+          }}
+        />
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" className="size-9 rounded-full" aria-label="Emoji">
+            <Smile className="h-5 w-5" />
+          </Button>
+          <Button
+            variant="default"
+            size="icon"
+            className="size-9 rounded-full"
+            aria-label="Senden"
+            onClick={handleSend}
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Chatbox;

--- a/src/components/forumlist/ForumRow.tsx
+++ b/src/components/forumlist/ForumRow.tsx
@@ -1,0 +1,82 @@
+import { memo } from "react";
+import { motion } from "framer-motion";
+import * as Icons from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ForumNode } from "@/lib/api/types";
+import { Badge } from "@/components/ui/badge";
+import { PostCountBadge } from "./PostCountBadge";
+import { LastPostMeta } from "./LastPostMeta";
+
+const iconLibrary = Icons as unknown as Record<string, LucideIcon>;
+
+function resolveIcon(name?: string) {
+  if (!name) return null;
+  const IconComponent = iconLibrary[name];
+  return IconComponent ?? null;
+}
+
+type ForumRowProps = {
+  data: ForumNode;
+};
+
+const ForumRowComponent = ({ data }: ForumRowProps) => {
+  const IconComponent = resolveIcon(data.icon);
+
+  return (
+    <motion.article
+      layout
+      whileHover={{ y: -1 }}
+      className="group grid grid-cols-[44px_minmax(0,1fr)] items-start gap-4 px-4 py-4 transition-colors hover:bg-muted/10 md:grid-cols-[44px_minmax(0,1fr)_96px_minmax(220px,0.8fr)] md:items-center md:px-5"
+    >
+      <div className="flex items-center justify-center md:self-stretch">
+        {data.emoji ? (
+          <span className="text-2xl">{data.emoji}</span>
+        ) : IconComponent ? (
+          <IconComponent className="h-6 w-6 text-muted-foreground" aria-hidden />
+        ) : (
+          <Icons.Gamepad2 className="h-6 w-6 text-muted-foreground" aria-hidden />
+        )}
+      </div>
+
+      <div className="space-y-1 md:self-center">
+        <h3 className="text-base font-medium tracking-tight md:text-lg">{data.title}</h3>
+        {data.description ? (
+          <p className="text-xs text-muted-foreground md:text-sm">{data.description}</p>
+        ) : null}
+        {data.children?.length ? (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {data.children.slice(0, 4).map((child) => (
+              <Badge
+                key={`sub_${child.id}`}
+                variant="secondary"
+                className="rounded-full px-2.5 py-0.5 text-[11px]"
+              >
+                {child.title}
+              </Badge>
+            ))}
+            {data.children.length > 4 ? (
+              <span className="text-[11px] text-muted-foreground">
+                +{data.children.length - 4} more
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="hidden md:flex md:items-center md:justify-center">
+        <PostCountBadge count={data.posts} />
+      </div>
+
+      <div className="hidden md:flex md:justify-end">
+        <LastPostMeta data={data.lastPost} />
+      </div>
+
+      <div className="col-span-full flex w-full items-start justify-between gap-4 md:hidden">
+        <PostCountBadge count={data.posts} className="mx-0" />
+        <LastPostMeta data={data.lastPost} align="left" className="flex-1" />
+      </div>
+    </motion.article>
+  );
+};
+
+export const ForumRow = memo(ForumRowComponent);

--- a/src/components/forumlist/LastPostMeta.tsx
+++ b/src/components/forumlist/LastPostMeta.tsx
@@ -1,0 +1,39 @@
+import type { LastPost } from "@/lib/api/types";
+import { cn } from "@/lib/utils/cn";
+
+type LastPostMetaProps = {
+  data?: LastPost;
+  className?: string;
+  align?: "left" | "right";
+};
+
+export function LastPostMeta({ data, className, align = "right" }: LastPostMetaProps) {
+  const textAlignment = align === "left" ? "text-left" : "text-right";
+  const justify = align === "left" ? "justify-start" : "justify-end";
+
+  if (!data) {
+    return (
+      <div className={cn("text-sm text-muted-foreground/70", textAlignment, className)}>
+        No posts yet
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex items-center gap-3", justify, className)}>
+      <img
+        src={data.author.avatarUrl ?? "/avatar.png"}
+        className="h-8 w-8 rounded-full ring-2 ring-background/70"
+        alt={data.author.name}
+      />
+      <div className={cn("text-sm", textAlignment)}>
+        <a className="block text-sm font-medium line-clamp-1 hover:underline" href="#">
+          {data.threadTitle}
+        </a>
+        <p className="text-xs text-muted-foreground">
+          By <span className="font-medium">{data.author.name}</span>, {new Date(data.createdAt).toLocaleString()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/forumlist/PostCountBadge.tsx
+++ b/src/components/forumlist/PostCountBadge.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils/cn";
+
+export function PostCountBadge({
+  count,
+  label = "posts",
+  className
+}: {
+  count: number;
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex h-16 w-16 flex-col items-center justify-center rounded-full bg-muted/30 text-center",
+        "mx-auto",
+        className
+      )}
+    >
+      <div className="text-xl font-semibold tabular-nums">{count}</div>
+      <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</div>
+    </div>
+  );
+}

--- a/src/components/forumlist/Section.tsx
+++ b/src/components/forumlist/Section.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+import type { ForumSection } from "@/lib/api/types";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils/cn";
+import { ForumRow } from "./ForumRow";
+
+type SectionProps = {
+  section: ForumSection;
+  defaultOpen?: boolean;
+};
+
+export function Section({ section, defaultOpen = true }: SectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="rounded-2xl border border-border/60 bg-card/60 backdrop-blur">
+      <div className="flex items-center justify-between border-b border-border/60 px-4 py-3 md:px-5">
+        <div className="flex items-center gap-3">
+          <span className="size-1.5 rounded-full bg-primary/70" />
+          <h2 className="text-sm font-semibold uppercase tracking-tight text-muted-foreground md:text-base">
+            {section.title}
+          </h2>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="rounded-full"
+          aria-label={open ? "Collapse" : "Expand"}
+          aria-expanded={open}
+          onClick={() => setOpen((prev) => !prev)}
+        >
+          <ChevronDown
+            className={cn("h-5 w-5 transition-transform", open ? "rotate-180" : "")}
+            aria-hidden="true"
+          />
+        </Button>
+      </div>
+      <AnimatePresence initial={false}>
+        {open ? (
+          <motion.div
+            key="content"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: { height: "auto", opacity: 1 },
+              collapsed: { height: 0, opacity: 0 }
+            }}
+            transition={{ duration: 0.28, ease: [0.22, 1, 0.36, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="divide-y divide-border/60">
+              {section.forums.map((forum) => (
+                <ForumRow key={forum.id} data={forum} />
+              ))}
+            </div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/lib/api/mockApi.ts
+++ b/src/lib/api/mockApi.ts
@@ -4,6 +4,8 @@ import type {
   Category,
   CategoryFilter,
   ChatMessage,
+  ForumNode,
+  ForumSection,
   PaginatedResponse,
   Post,
   Stats,
@@ -48,6 +50,237 @@ const users: User[] = Array.from({ length: 12 }).map((_, idx) => ({
   avatarUrl: `https://i.pravatar.cc/150?img=${idx + 12}`,
   createdAt: new Date(Date.now() - idx * 3600 * 24 * 1000).toISOString()
 }));
+
+const makeLastPost = (id: string, threadTitle: string, userIndex: number, minutesAgo: number) => {
+  const author = users[userIndex % users.length];
+  return {
+    id,
+    threadTitle,
+    author: {
+      id: author.id,
+      name: author.name,
+      avatarUrl: author.avatarUrl
+    },
+    createdAt: new Date(Date.now() - minutesAgo * 60 * 1000).toISOString()
+  };
+};
+
+const forumBoard: ForumSection[] = [
+  {
+    id: "section-command",
+    title: "Command Center",
+    forums: [
+      {
+        id: "forum-briefings",
+        emoji: "🛰️",
+        title: "Signal Uplink",
+        description: "Daily drops of industry intel, patch alerts and dev diaries.",
+        posts: 1458,
+        topics: 238,
+        lastPost: makeLastPost("lp-briefings", "Patch 12.8: Photon Siege Notes", 1, 18),
+        children: [
+          { id: "sub-briefings-1", title: "Patch Radar", posts: 86 },
+          { id: "sub-briefings-2", title: "Dev Responses", posts: 42 },
+          { id: "sub-briefings-3", title: "Event Alerts", posts: 37 }
+        ]
+      },
+      {
+        id: "forum-releases",
+        icon: "Rocket",
+        title: "Launch Hangar",
+        description: "Track AAA rollouts, early access windows and roadmap reveals.",
+        posts: 987,
+        topics: 164,
+        lastPost: makeLastPost("lp-releases", "Echo Drift releasing on May 28", 4, 65),
+        children: [
+          { id: "sub-releases-1", title: "AAA", posts: 58 },
+          { id: "sub-releases-2", title: "Indie Signals", posts: 44 },
+          { id: "sub-releases-3", title: "Roadmaps", posts: 33 }
+        ]
+      },
+      {
+        id: "forum-deepdives",
+        icon: "Satellite",
+        title: "Deep Scan Reports",
+        description: "Long-form breakdowns, metrics and meta analyses from the lab.",
+        posts: 1214,
+        topics: 192,
+        lastPost: makeLastPost("lp-deepdives", "Telemetry on VR retention", 6, 142),
+        children: [
+          { id: "sub-deepdives-1", title: "Analytics", posts: 71 },
+          { id: "sub-deepdives-2", title: "Design Diaries", posts: 29 },
+          { id: "sub-deepdives-3", title: "Research", posts: 40 },
+          { id: "sub-deepdives-4", title: "Field Notes", posts: 18 }
+        ]
+      },
+      {
+        id: "forum-market",
+        emoji: "🧠",
+        title: "Market Signals",
+        description: "Benchmarks, funding rounds and strategic plays from publishers.",
+        posts: 764,
+        topics: 118,
+        lastPost: makeLastPost("lp-market", "HoloWorks closes Series B", 8, 220),
+        children: [
+          { id: "sub-market-1", title: "Investments", posts: 32 },
+          { id: "sub-market-2", title: "Partnerships", posts: 27 },
+          { id: "sub-market-3", title: "Hiring", posts: 24 }
+        ]
+      }
+    ]
+  },
+  {
+    id: "section-competitive",
+    title: "Competitive Operations",
+    forums: [
+      {
+        id: "forum-strats",
+        icon: "Sword",
+        title: "Tactics Lab",
+        description: "Playbook swaps, comp science and counter-strat breakdowns.",
+        posts: 1890,
+        topics: 256,
+        lastPost: makeLastPost("lp-strats", "Countering aerial rush lanes", 2, 44),
+        children: [
+          { id: "sub-strats-1", title: "Meta Watch", posts: 74 },
+          { id: "sub-strats-2", title: "Scrim Logs", posts: 61 },
+          { id: "sub-strats-3", title: "Coach Calls", posts: 35 },
+          { id: "sub-strats-4", title: "Theorycraft", posts: 48 }
+        ]
+      },
+      {
+        id: "forum-tournaments",
+        icon: "Trophy",
+        title: "Tournament Ops",
+        description: "Bracket intel, LAN prep workflows and official rule updates.",
+        posts: 1126,
+        topics: 174,
+        lastPost: makeLastPost("lp-tournaments", "Nexus Masters qualifiers recap", 9, 16),
+        children: [
+          { id: "sub-tournaments-1", title: "Qualifier News", posts: 53 },
+          { id: "sub-tournaments-2", title: "LAN Logistics", posts: 41 },
+          { id: "sub-tournaments-3", title: "Match VODs", posts: 46 }
+        ]
+      },
+      {
+        id: "forum-loadouts",
+        emoji: "🎯",
+        title: "Gear Vault",
+        description: "Controller tuning, PC builds and performance-optimised presets.",
+        posts: 1387,
+        topics: 210,
+        lastPost: makeLastPost("lp-loadouts", "Updated gyro curves for Helix", 10, 72),
+        children: [
+          { id: "sub-loadouts-1", title: "PC", posts: 88 },
+          { id: "sub-loadouts-2", title: "Console", posts: 57 },
+          { id: "sub-loadouts-3", title: "Mobile", posts: 28 },
+          { id: "sub-loadouts-4", title: "Peripherals", posts: 39 }
+        ]
+      },
+      {
+        id: "forum-community",
+        icon: "Users",
+        title: "Crew Briefing",
+        description: "Clan recruitment, scrim finders and looking-for-group beacons.",
+        posts: 842,
+        topics: 129,
+        lastPost: makeLastPost("lp-community", "Looking for flex support tonight", 3, 8),
+        children: [
+          { id: "sub-community-1", title: "Recruitment", posts: 48 },
+          { id: "sub-community-2", title: "LFG", posts: 57 },
+          { id: "sub-community-3", title: "Rosters", posts: 31 }
+        ]
+      }
+    ]
+  },
+  {
+    id: "section-creative",
+    title: "Creative Labs",
+    forums: [
+      {
+        id: "forum-prototype",
+        icon: "Beaker",
+        title: "Prototype Lab",
+        description: "Share greybox builds, systems experiments and feedback requests.",
+        posts: 658,
+        topics: 97,
+        lastPost: makeLastPost("lp-prototype", "New movement sandbox build", 5, 33),
+        children: [
+          { id: "sub-prototype-1", title: "Mechanics", posts: 28 },
+          { id: "sub-prototype-2", title: "Level Design", posts: 35 },
+          { id: "sub-prototype-3", title: "AI", posts: 22 }
+        ]
+      },
+      {
+        id: "forum-art",
+        emoji: "🎨",
+        title: "Visual Forge",
+        description: "Concept art jams, shader breakdowns and asset polish sessions.",
+        posts: 1542,
+        topics: 201,
+        lastPost: makeLastPost("lp-art", "Photon Knight key art WIP", 7, 25),
+        children: [
+          { id: "sub-art-1", title: "Concept", posts: 61 },
+          { id: "sub-art-2", title: "3D", posts: 47 },
+          { id: "sub-art-3", title: "UI", posts: 32 },
+          { id: "sub-art-4", title: "Animation", posts: 29 }
+        ]
+      },
+      {
+        id: "forum-audio",
+        icon: "AudioWaveform",
+        title: "Sound Lab",
+        description: "Sound design sessions, adaptive scoring and VO pipelines.",
+        posts: 512,
+        topics: 83,
+        lastPost: makeLastPost("lp-audio", "Layered ambience kit release", 11, 95),
+        children: [
+          { id: "sub-audio-1", title: "SFX", posts: 26 },
+          { id: "sub-audio-2", title: "Music", posts: 31 },
+          { id: "sub-audio-3", title: "VO", posts: 18 }
+        ]
+      },
+      {
+        id: "forum-code",
+        icon: "Code2",
+        title: "Engine Room",
+        description: "Optimization wins, tooling scripts and pipeline automation.",
+        posts: 1783,
+        topics: 266,
+        lastPost: makeLastPost("lp-code", "Modular input graph refactor", 0, 54),
+        children: [
+          { id: "sub-code-1", title: "Unity", posts: 65 },
+          { id: "sub-code-2", title: "Unreal", posts: 72 },
+          { id: "sub-code-3", title: "Custom", posts: 44 },
+          { id: "sub-code-4", title: "Tooling", posts: 39 }
+        ]
+      }
+    ]
+  }
+];
+
+const cloneForumNode = (node: ForumNode): ForumNode => ({
+  ...node,
+  lastPost: node.lastPost
+    ? {
+        ...node.lastPost,
+        author: { ...node.lastPost.author }
+      }
+    : undefined,
+  children: node.children?.map(cloneForumNode)
+});
+
+const cloneForumBoard = (): ForumSection[] =>
+  forumBoard.map((section) => ({
+    ...section,
+    forums: section.forums.map(cloneForumNode)
+  }));
+
+const fetchForumBoard = async (): Promise<ForumSection[]> => {
+  await wait();
+  maybeFail();
+  return cloneForumBoard();
+};
 
 const categories: Category[] = [
   {
@@ -410,6 +643,9 @@ export const mockApi = {
     maybeFail();
     return posts.filter((post) => post.threadId === threadId);
   },
+  async getForumBoard(): Promise<ForumSection[]> {
+    return fetchForumBoard();
+  },
   async createThread(data: Pick<ThreadWithMeta, "categoryId" | "title" | "tags"> & { body: string; authorId: string }): Promise<ThreadWithMeta> {
     await wait();
     maybeFail();
@@ -472,5 +708,9 @@ export const mockApi = {
     return users;
   }
 };
+
+export async function getForumBoard(): Promise<ForumSection[]> {
+  return fetchForumBoard();
+}
 
 export type MockApi = typeof mockApi;

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -7,6 +7,31 @@ export interface User {
   createdAt: string;
 }
 
+export interface LastPost {
+  id: ID;
+  threadTitle: string;
+  author: { id: ID; name: string; avatarUrl?: string };
+  createdAt: string;
+}
+
+export interface ForumNode {
+  id: ID;
+  emoji?: string;
+  icon?: string;
+  title: string;
+  description?: string;
+  posts: number;
+  topics?: number;
+  lastPost?: LastPost;
+  children?: ForumNode[];
+}
+
+export interface ForumSection {
+  id: ID;
+  title: string;
+  forums: ForumNode[];
+}
+
 export interface SubCategory {
   id: ID;
   name: string;

--- a/src/routes/Forums.tsx
+++ b/src/routes/Forums.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from "react";
+import PageTransition from "@/components/layout/PageTransition";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import Chatbox from "@/components/chat/Chatbox";
+import { Section } from "@/components/forumlist/Section";
+import type { ForumSection } from "@/lib/api/types";
+import { getForumBoard } from "@/lib/api/mockApi";
+
+const Forums = () => {
+  const [sections, setSections] = useState<ForumSection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadBoard = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await getForumBoard();
+      setSections(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load forum board");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadBoard();
+  }, [loadBoard]);
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-[1200px] px-4 sm:px-6 2xl:max-w-[1320px]">
+        <div className="space-y-8 py-10 md:space-y-10">
+          <header className="flex items-center justify-between gap-3">
+            <h1 className="text-2xl font-semibold tracking-tight md:text-3xl">Forums</h1>
+            <Button className="rounded-xl px-4 md:px-5" variant="default">
+              Start new topic
+            </Button>
+          </header>
+
+          <Chatbox />
+
+          {loading ? (
+            <div className="space-y-4">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={`skeleton-${index}`}
+                  className="rounded-2xl border border-border/50 bg-card/40 backdrop-blur"
+                >
+                  <div className="flex items-center justify-between border-b border-border/60 px-4 py-3 md:px-5">
+                    <div className="flex items-center gap-3">
+                      <span className="size-1.5 rounded-full bg-primary/60" />
+                      <Skeleton className="h-3 w-40" />
+                    </div>
+                    <Skeleton className="h-8 w-8 rounded-full" />
+                  </div>
+                  <div className="space-y-4 p-4 md:p-6">
+                    {Array.from({ length: 2 }).map((__, row) => (
+                      <div key={`row-${row}`} className="grid grid-cols-[44px_minmax(0,1fr)] gap-4">
+                        <Skeleton className="h-10 w-10 rounded-full" />
+                        <div className="space-y-2">
+                          <Skeleton className="h-4 w-56" />
+                          <Skeleton className="h-3 w-32" />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : error ? (
+            <div className="rounded-2xl border border-destructive/40 bg-destructive/10 p-6 text-sm text-destructive">
+              <p className="font-medium">{error}</p>
+              <Button variant="outline" className="mt-4 rounded-xl" onClick={() => loadBoard()}>
+                Retry loading
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {sections.map((section) => (
+                <Section key={section.id} section={section} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </PageTransition>
+  );
+};
+
+export default Forums;


### PR DESCRIPTION
## Summary
- add a dedicated /forums page with a chatbox header and collapsible board sections
- build reusable forum list components for rows, badges, and last-post metadata
- extend the mock API and types with forum board data and a getForumBoard helper

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d818c6c6c88327b8dab8183f1e73ed