### PR TITLE
Refine forum layout and category grid spacing

### DIFF
--- a/src/components/forum/CategoryCard.tsx
+++ b/src/components/forum/CategoryCard.tsx
@@ -19,7 +19,6 @@ import {
   Users
 } from "lucide-react";
 import { useUiStore } from "@/store/uiStore";
-import SubcategoryCollapse from "@/components/forum/SubcategoryCollapse";
 
 const iconMap: Record<string, LucideIcon> = {
   crosshair: Crosshair,
@@ -50,27 +49,37 @@ const CategoryCard = ({ category }: { category: Category }) => {
       className="block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       data-density={density}
     >
-      <Card className="relative h-full overflow-hidden rounded-2xl border-border/60 bg-card/80 shadow-[0_20px_45px_-28px_rgba(0,0,0,0.55)] transition-colors hover:border-primary/50 supports-[backdrop-filter]:bg-card/75">
-        <div
-          className="flex min-h-[180px] flex-col p-5 md:p-6 2xl:p-7 data-[density=compact]:p-4"
-          data-density={density}
-        >
+      <Card className="rounded-2xl border bg-card/80 backdrop-blur shadow-sm">
+        <div className="flex min-h-[190px] flex-col p-5 md:p-6 2xl:p-7 data-[density=compact]:p-4 md:data-[density=compact]:p-5" data-density={density}>
           <div className="flex items-center gap-3">
-            <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary">
-              <Icon className="h-5 w-5" aria-hidden="true" />
-            </span>
-            <h3 className="text-lg font-semibold tracking-tight md:text-xl">{category.name}</h3>
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10">
+              <Icon className="h-5 w-5 text-primary" aria-hidden="true" />
+            </div>
+            <h3 className="text-lg md:text-xl font-semibold tracking-tight">{category.name}</h3>
           </div>
 
-          {category.description ? (
-            <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
+          {category.description && (
+            <p className="mt-2 line-clamp-2 text-sm text-muted-foreground leading-relaxed">
               {category.description}
             </p>
-          ) : null}
+          )}
 
-          {category.subcategories?.length ? <SubcategoryCollapse subs={category.subcategories} /> : null}
+          {!!category.subcategories?.length && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {category.subcategories.slice(0, 6).map((s) => (
+                <span key={`sub_${s.id}`} className="rounded-full bg-secondary/60 px-2.5 py-1 text-[11px]">
+                  {s.name}
+                </span>
+              ))}
+              {category.subcategories.length > 6 && (
+                <button className="text-[11px] text-primary hover:underline">
+                  +{category.subcategories.length - 6} mehr
+                </button>
+              )}
+            </div>
+          )}
 
-          <div className="mt-auto flex items-center gap-3 pt-4 text-xs text-muted-foreground md:text-sm">
+          <div className="mt-auto pt-4 flex items-center gap-3 text-xs md:text-sm text-muted-foreground">
             <Badge variant="secondary" className="rounded-full px-2.5 py-0.5">
               {category.threadCount} Threads
             </Badge>

--- a/src/components/forum/CategorySection.tsx
+++ b/src/components/forum/CategorySection.tsx
@@ -1,0 +1,55 @@
+import { motion } from "framer-motion";
+import CategoryCard from "@/components/forum/CategoryCard";
+import type { Category } from "@/lib/api/types";
+
+const gridVariants = {
+  hidden: {},
+  show: {
+    transition: {
+      staggerChildren: 0.05,
+      delayChildren: 0.04
+    }
+  }
+};
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.32, ease: [0.22, 1, 0.36, 1] } }
+};
+
+interface CategorySectionProps {
+  categories: Category[];
+}
+
+export default function CategorySection({ categories }: CategorySectionProps) {
+  return (
+    <section
+      className="
+        [--card-min:280px]
+        sm:[--card-min:300px]
+        xl:[--card-min:320px]
+        2xl:[--card-min:340px]
+        space-y-4
+      "
+    >
+      {/* Toolbar (Suche/Sort/Filter) hier, optional sticky */}
+
+      <motion.div
+        variants={gridVariants}
+        initial="hidden"
+        animate="show"
+        className="
+          grid
+          [grid-template-columns:repeat(auto-fit,minmax(var(--card-min),1fr))]
+          gap-5 xl:gap-6 2xl:gap-7
+        "
+      >
+        {categories.map((c) => (
+          <motion.div key={`cat_${c.id}`} variants={cardVariants}>
+            <CategoryCard category={c} />
+          </motion.div>
+        ))}
+      </motion.div>
+    </section>
+  );
+}

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -12,7 +12,6 @@ import {
   SheetHeader,
   SheetTitle
 } from "@/components/ui/sheet";
-import { cn } from "@/lib/utils/cn";
 
 const RootLayout = ({ children }: PropsWithChildren) => {
   const sidebarLeftOpen = useUiStore((state) => state.sidebarLeftOpen);
@@ -24,48 +23,9 @@ const RootLayout = ({ children }: PropsWithChildren) => {
   return (
     <div className="flex min-h-screen flex-col">
       <Header />
-      <div className="flex-1 pt-4 md:pt-6">
-        <main
-          data-density={density}
-          className="mx-auto max-w-[1600px] px-4 sm:px-6 lg:px-8 2xl:max-w-[1720px] 2xl:px-10 3xl:max-w-[1880px]"
-        >
-          <div
-            className={cn(
-              "grid grid-cols-1 gap-6 items-start lg:grid-cols-[300px_minmax(640px,1fr)_380px] xl:gap-8 2xl:gap-10",
-              density === "compact" && "gap-5 xl:gap-6 2xl:gap-8"
-            )}
-          >
-            <aside
-              className={cn(
-                "sticky top-24 hidden space-y-4 lg:block",
-                density === "compact" && "space-y-3"
-              )}
-              data-density={density}
-            >
-              <SidebarLeftStats />
-            </aside>
-            <section
-              className={cn(
-                "mx-auto w-full max-w-[960px] space-y-6 md:space-y-8 2xl:max-w-[1040px]",
-                "lg:col-span-2 xl:col-span-1",
-                density === "compact" && "space-y-4 md:space-y-5"
-              )}
-              data-density={density}
-            >
-              {children}
-            </section>
-            <aside
-              className={cn(
-                "sticky top-24 hidden space-y-4 xl:block w-[340px] xl:w-[360px] 2xl:w-[380px]",
-                density === "compact" && "space-y-3"
-              )}
-              data-density={density}
-            >
-              <SidebarRightTrends />
-            </aside>
-          </div>
-        </main>
-      </div>
+      <main data-density={density} className="flex-1 pt-4 md:pt-6">
+        {children}
+      </main>
       <Footer />
       <div className="fixed bottom-6 right-6 z-40">
         <ChatDock className="w-[360px] 2xl:w-[380px]" />

--- a/src/routes/Forum.tsx
+++ b/src/routes/Forum.tsx
@@ -3,7 +3,6 @@ import { useForumStore } from "@/store/forumStore";
 import { useUiStore } from "@/store/uiStore";
 import PageTransition from "@/components/layout/PageTransition";
 import TabsBar from "@/components/forum/TabsBar";
-import CategoryCard from "@/components/forum/CategoryCard";
 import ThreadItem from "@/components/forum/ThreadItem";
 import LoadingSkeleton from "@/components/common/LoadingSkeleton";
 import ErrorState from "@/components/common/ErrorState";
@@ -20,10 +19,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils/cn";
 import type { CategoryFilter } from "@/lib/api/types";
+import SidebarLeftStats from "@/components/layout/SidebarLeftStats";
+import SidebarRightTrends from "@/components/layout/SidebarRightTrends";
+import CategorySection from "@/components/forum/CategorySection";
 
 const CATEGORY_SORT_OPTIONS: Array<{ value: NonNullable<CategoryFilter["sort"]>; label: string }> = [
   { value: "name", label: "Name A–Z" },
@@ -31,21 +32,6 @@ const CATEGORY_SORT_OPTIONS: Array<{ value: NonNullable<CategoryFilter["sort"]>;
   { value: "posts", label: "Meiste Posts" },
   { value: "new", label: "Neu hinzugefügt" }
 ];
-
-const gridVariants = {
-  hidden: {},
-  show: {
-    transition: {
-      staggerChildren: 0.05,
-      delayChildren: 0.04
-    }
-  }
-};
-
-const cardVariants = {
-  hidden: { opacity: 0, y: 16 },
-  show: { opacity: 1, y: 0, transition: { duration: 0.32, ease: [0.22, 1, 0.36, 1] } }
-};
 
 const Forum = () => {
   const navigate = useNavigate();
@@ -147,202 +133,224 @@ const Forum = () => {
 
   return (
     <PageTransition>
-      <div className="space-y-6 md:space-y-8 data-[density=compact]:space-y-4 md:data-[density=compact]:space-y-5" data-density={density}>
-        <div
-          className="mx-auto w-full max-w-[1040px] rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] supports-[backdrop-filter]:bg-background/70 md:p-6 2xl:p-7 data-[density=compact]:p-4 md:data-[density=compact]:p-5"
-          data-density={density}
-        >
-          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between data-[density=compact]:gap-4" data-density={density}>
-            <div className="space-y-2">
-              <h1 className="text-3xl font-semibold tracking-tight">Forum Übersicht</h1>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Was passiert gerade in der NexusLabs Community?
-              </p>
-            </div>
-            <Button size="lg" onClick={() => navigate("/create")} className="self-start md:self-auto">
-              <MessageSquarePlus className="mr-2 h-4 w-4" />
-              Neuer Thread
-            </Button>
-          </div>
-        </div>
+      <div className="min-h-screen" data-density={density}>
+        <main className="mx-auto max-w-[1600px] 2xl:max-w-[1720px] px-4 sm:px-6 lg:px-8 2xl:px-10 space-y-8">
+          <div className="grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)_360px] gap-6 xl:gap-8 2xl:gap-10 items-start">
+            <aside className="hidden lg:block sticky top-24 space-y-4">
+              <SidebarLeftStats />
+            </aside>
 
-        <section className="mb-6 mt-6 md:mb-8 md:mt-8 2xl:mt-10" data-density={density}>
-          <header className="sticky top-20 z-20 -mx-4 border-b border-border/60 bg-background/60 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/70 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8 2xl:-mx-10 2xl:px-10">
-            <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-3 sm:flex-row sm:items-center sm:justify-between 2xl:max-w-[1160px]">
-              <div className="flex w-full flex-col gap-2 sm:max-w-md">
-                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</span>
-                <SearchBar
-                  value={searchTerm}
-                  onChange={(event) => setSearchTerm(event.target.value)}
-                  placeholder="Suche Kategorien/Subkategorien…"
-                  className="w-full"
-                  inputClassName="h-10 rounded-xl"
-                />
-              </div>
-              <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-9 rounded-full px-4 text-xs font-medium"
-                    >
-                      <span className="mr-2 inline-flex items-center gap-1">
-                        <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
-                        {activeSortLabel}
-                      </span>
-                      <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="min-w-[12rem]">
-                    <DropdownMenuLabel>Sortieren nach</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    {CATEGORY_SORT_OPTIONS.map((option) => (
-                      <DropdownMenuItem
-                        key={option.value}
-                        onSelect={() => handleSortChange(option.value)}
-                        className={cn(
-                          "flex items-center justify-between gap-4 text-sm",
-                          categoryFilters.sort === option.value ? "text-primary" : undefined
-                        )}
-                      >
-                        {option.label}
-                        {categoryFilters.sort === option.value ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-9 rounded-full px-4 text-xs font-medium"
-                    >
-                      <span className="mr-2">{activeTagLabel}</span>
-                      <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="min-w-[12rem]">
-                    <DropdownMenuLabel>Genre / Tag</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onSelect={() => handleTagSelect(undefined)}
-                      className={cn(
-                        "flex items-center justify-between gap-4 text-sm",
-                        !categoryFilters.tag ? "text-primary" : undefined
-                      )}
-                    >
-                      Alle Genres/Tags
-                      {!categoryFilters.tag ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
-                    </DropdownMenuItem>
-                    {categoryTags.map((tag) => (
-                      <DropdownMenuItem
-                        key={tag}
-                        onSelect={() => handleTagSelect(tag)}
-                        className={cn(
-                          "flex items-center justify-between gap-4 text-sm",
-                          categoryFilters.tag === tag ? "text-primary" : undefined
-                        )}
-                      >
-                        {tag}
-                        {categoryFilters.tag === tag ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleToggleOnlyNew}
-                  aria-pressed={categoryFilters.onlyNew}
-                  className={cn(
-                    "h-9 rounded-full px-4 text-xs font-medium transition-colors",
-                    categoryFilters.onlyNew
-                      ? "border-primary/50 bg-primary/10 text-primary hover:bg-primary/15"
-                      : "hover:bg-muted/60"
-                  )}
+            <section className="mx-auto w-full max-w-[1120px] 2xl:max-w-[1240px] space-y-8">
+              <div
+                className="space-y-6 md:space-y-8 data-[density=compact]:space-y-4 md:data-[density=compact]:space-y-5"
+                data-density={density}
+              >
+                <div
+                  className="rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] supports-[backdrop-filter]:bg-background/70 md:p-6 2xl:p-7 data-[density=compact]:p-4 md:data-[density=compact]:p-5"
+                  data-density={density}
                 >
-                  <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
-                  Nur mit neuen Beiträgen
-                </Button>
-              </div>
-            </div>
-          </header>
-
-          <div className="mx-auto w-full max-w-[1040px] px-4 pt-4 sm:px-6 lg:px-8 2xl:max-w-[1160px] 2xl:px-10">
-            {isInitialCategoryLoading ? (
-              <LoadingSkeleton />
-            ) : categoryError ? (
-              <ErrorState message={error ?? "Es ist ein Fehler aufgetreten."} onRetry={() => fetchCategories()} />
-            ) : isCategoryEmpty ? (
-              <div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-10 text-center text-sm text-muted-foreground">
-                Keine Kategorien gefunden. Versuche es mit anderen Filtern.
-              </div>
-            ) : (
-              <>
-                <motion.div
-                  variants={gridVariants}
-                  initial="hidden"
-                  animate="show"
-                  className="grid [grid-template-columns:repeat(auto-fit,minmax(260px,1fr))] gap-5 xl:gap-6 2xl:gap-7"
-                >
-                  {categories.map((category) => (
-                    <motion.div key={`cat_${category.id}`} variants={cardVariants}>
-                      <CategoryCard category={category} />
-                    </motion.div>
-                  ))}
-                </motion.div>
-
-                {hasMoreCategories ? (
-                  <div className="mt-6 flex justify-center">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="rounded-full px-6"
-                      disabled={loadingMoreCategories}
-                      onClick={handleLoadMoreCategories}
-                    >
-                      {loadingMoreCategories ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-                          Lädt weitere Kategorien…
-                        </>
-                      ) : remainingCategories > 0 ? (
-                        `Mehr laden (${remainingCategories})`
-                      ) : (
-                        "Mehr laden"
-                      )}
+                  <div
+                    className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between data-[density=compact]:gap-4"
+                    data-density={density}
+                  >
+                    <div className="space-y-2">
+                      <h1 className="text-3xl font-semibold tracking-tight">Forum Übersicht</h1>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        Was passiert gerade in der NexusLabs Community?
+                      </p>
+                    </div>
+                    <Button size="lg" onClick={() => navigate("/create")} className="self-start md:self-auto">
+                      <MessageSquarePlus className="mr-2 h-4 w-4" />
+                      Neuer Thread
                     </Button>
                   </div>
-                ) : null}
-              </>
-            )}
-          </div>
-        </section>
+                </div>
+              </div>
 
-        <section className="space-y-5 data-[density=compact]:space-y-4" data-density={density}>
-          <TabsBar onChange={(value) => fetchThreads({ sort: value as typeof activeTab })} />
-          {loadingThreads && threads.length === 0 ? (
-            <LoadingSkeleton />
-          ) : error && threads.length === 0 ? (
-            <ErrorState message={error} onRetry={() => fetchThreads({ sort: activeTab })} />
-          ) : threads.length === 0 ? (
-            <EmptyState />
-          ) : (
-            <div
-              className="flex flex-col divide-y divide-border/60 space-y-4 rounded-3xl border border-border/60 bg-background/60 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] supports-[backdrop-filter]:bg-background/70 md:space-y-5 2xl:space-y-6 data-[density=compact]:space-y-3 md:data-[density=compact]:space-y-4"
-              data-density={density}
-            >
-              {threads.map((thread) => (
-                <ThreadItem key={thread.id} thread={thread} />
-              ))}
-            </div>
-          )}
-        </section>
+              <section
+                className="space-y-6 md:space-y-8 data-[density=compact]:space-y-4 md:data-[density=compact]:space-y-5"
+                data-density={density}
+              >
+                <header className="sticky top-20 z-20 rounded-3xl border border-border/60 bg-background/70 p-4 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-background/75 sm:p-5 md:p-6 2xl:p-7">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex w-full flex-col gap-2 sm:max-w-md">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Kategorien</span>
+                      <SearchBar
+                        value={searchTerm}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        placeholder="Suche Kategorien/Subkategorien…"
+                        className="w-full"
+                        inputClassName="h-10 rounded-xl"
+                      />
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-9 rounded-full px-4 text-xs font-medium"
+                          >
+                            <span className="mr-2 inline-flex items-center gap-1">
+                              <SlidersHorizontal className="h-3.5 w-3.5" aria-hidden="true" />
+                              {activeSortLabel}
+                            </span>
+                            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="min-w-[12rem]">
+                          <DropdownMenuLabel>Sortieren nach</DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          {CATEGORY_SORT_OPTIONS.map((option) => (
+                            <DropdownMenuItem
+                              key={option.value}
+                              onSelect={() => handleSortChange(option.value)}
+                              className={cn(
+                                "flex items-center justify-between gap-4 text-sm",
+                                categoryFilters.sort === option.value ? "text-primary" : undefined
+                              )}
+                            >
+                              {option.label}
+                              {categoryFilters.sort === option.value ? (
+                                <Check className="h-4 w-4" aria-hidden="true" />
+                              ) : null}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-9 rounded-full px-4 text-xs font-medium"
+                          >
+                            <span className="mr-2">{activeTagLabel}</span>
+                            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="min-w-[12rem]">
+                          <DropdownMenuLabel>Genre / Tag</DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onSelect={() => handleTagSelect(undefined)}
+                            className={cn(
+                              "flex items-center justify-between gap-4 text-sm",
+                              !categoryFilters.tag ? "text-primary" : undefined
+                            )}
+                          >
+                            Alle Genres/Tags
+                            {!categoryFilters.tag ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
+                          </DropdownMenuItem>
+                          {categoryTags.map((tag) => (
+                            <DropdownMenuItem
+                              key={tag}
+                              onSelect={() => handleTagSelect(tag)}
+                              className={cn(
+                                "flex items-center justify-between gap-4 text-sm",
+                                categoryFilters.tag === tag ? "text-primary" : undefined
+                              )}
+                            >
+                              {tag}
+                              {categoryFilters.tag === tag ? <Check className="h-4 w-4" aria-hidden="true" /> : null}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={handleToggleOnlyNew}
+                        aria-pressed={categoryFilters.onlyNew}
+                        className={cn(
+                          "h-9 rounded-full px-4 text-xs font-medium transition-colors",
+                          categoryFilters.onlyNew
+                            ? "border-primary/50 bg-primary/10 text-primary hover:bg-primary/15"
+                            : "hover:bg-muted/60"
+                        )}
+                      >
+                        <Sparkles className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                        Nur mit neuen Beiträgen
+                      </Button>
+                    </div>
+                  </div>
+                </header>
+
+                <div className="space-y-6 md:space-y-8">
+                  {isInitialCategoryLoading ? (
+                    <LoadingSkeleton />
+                  ) : categoryError ? (
+                    <ErrorState
+                      message={error ?? "Es ist ein Fehler aufgetreten."}
+                      onRetry={() => fetchCategories()}
+                    />
+                  ) : isCategoryEmpty ? (
+                    <div className="rounded-2xl border border-dashed border-border/60 bg-muted/10 p-10 text-center text-sm text-muted-foreground">
+                      Keine Kategorien gefunden. Versuche es mit anderen Filtern.
+                    </div>
+                  ) : (
+                    <>
+                      <CategorySection categories={categories} />
+
+                      {hasMoreCategories ? (
+                        <div className="mt-6 flex justify-center">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="rounded-full px-6"
+                            disabled={loadingMoreCategories}
+                            onClick={handleLoadMoreCategories}
+                          >
+                            {loadingMoreCategories ? (
+                              <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                                Lädt weitere Kategorien…
+                              </>
+                            ) : remainingCategories > 0 ? (
+                              `Mehr laden (${remainingCategories})`
+                            ) : (
+                              "Mehr laden"
+                            )}
+                          </Button>
+                        </div>
+                      ) : null}
+                    </>
+                  )}
+                </div>
+              </section>
+
+              <section
+                className="space-y-6 md:space-y-8 data-[density=compact]:space-y-4 md:data-[density=compact]:space-y-5"
+                data-density={density}
+              >
+                <TabsBar onChange={(value) => fetchThreads({ sort: value as typeof activeTab })} />
+                {loadingThreads && threads.length === 0 ? (
+                  <LoadingSkeleton />
+                ) : error && threads.length === 0 ? (
+                  <ErrorState message={error} onRetry={() => fetchThreads({ sort: activeTab })} />
+                ) : threads.length === 0 ? (
+                  <EmptyState />
+                ) : (
+                  <div
+                    className="flex flex-col divide-y divide-border/60 space-y-6 rounded-3xl border border-border/60 bg-background/60 p-5 shadow-[0_8px_30px_-12px_rgba(0,0,0,0.45)] supports-[backdrop-filter]:bg-background/70 md:space-y-7 md:p-6 2xl:space-y-8 2xl:p-7 data-[density=compact]:space-y-4 md:data-[density=compact]:space-y-5"
+                    data-density={density}
+                  >
+                    {threads.map((thread) => (
+                      <ThreadItem key={thread.id} thread={thread} />
+                    ))}
+                  </div>
+                )}
+              </section>
+            </section>
+
+            <aside className="hidden xl:block sticky top-24 space-y-4 w-[360px]">
+              <SidebarRightTrends />
+            </aside>
+          </div>
+        </main>
       </div>
     </PageTransition>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -24,6 +24,7 @@
   --input: 217 33% 18%;
   --ring: 184 100% 50%;
   --radius: 0.95rem;
+  --fs-body: clamp(0.98rem, 0.25vw + 0.92rem, 1.05rem);
   --step-0: clamp(0.95rem, 0.25vw + 0.9rem, 1.05rem);
   --step-1: clamp(1.15rem, 0.5vw + 1rem, 1.35rem);
   --step-2: clamp(1.35rem, 0.7vw + 1.1rem, 1.6rem);
@@ -56,7 +57,7 @@
 body {
   @apply bg-background text-foreground antialiased;
   min-height: 100vh;
-  font-size: var(--step-0);
+  font-size: var(--fs-body);
   line-height: 1.65;
   letter-spacing: 0.01em;
   background-image: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.2), transparent 45%),
@@ -67,8 +68,7 @@ body {
 
 h1,
 h2,
-h3,
-h4 {
+h3 {
   letter-spacing: -0.015em;
 }
 


### PR DESCRIPTION
## Summary
- limit the forum page to a three-column grid with centered main content and sticky sidebars
- add a responsive category section component with wider cards and updated chip display
- refresh global typography scale and simplify the root layout container to let pages control width

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d81c9b5bb083278aa6bf709d691c58