### PR TITLE
Implement paginated thread comments

### DIFF
--- a/src/components/common/Pagination.tsx
+++ b/src/components/common/Pagination.tsx
@@ -1,0 +1,88 @@
+import { Button } from "@/components/ui/button";
+
+type RangeItem = number | "…";
+
+function buildRange(page: number, total: number, siblings = 1, boundaries = 1): RangeItem[] {
+  const start = Math.max(1, page - siblings);
+  const end = Math.min(total, page + siblings);
+  const items: RangeItem[] = [];
+
+  for (let i = 1; i <= boundaries && i <= total; i += 1) {
+    items.push(i);
+  }
+  if (start > boundaries + 1) {
+    items.push("…");
+  }
+  for (let i = start; i <= end; i += 1) {
+    if (i > boundaries && i <= total - boundaries) {
+      items.push(i);
+    }
+  }
+  if (end < total - boundaries) {
+    items.push("…");
+  }
+  for (let i = Math.max(total - boundaries + 1, boundaries + 1); i <= total; i += 1) {
+    if (i > 0) {
+      items.push(i);
+    }
+  }
+
+  return items.filter((value, index, array) => array.indexOf(value) === index);
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  onPageChange
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (p: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+  const clamp = (p: number) => Math.min(Math.max(p, 1), totalPages);
+  const range = buildRange(page, totalPages);
+
+  return (
+    <nav
+      className="flex items-center justify-center gap-1 py-4"
+      aria-label="Kommentare paginieren"
+    >
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onPageChange(clamp(page - 1))}
+        disabled={page === 1}
+        aria-label="Vorherige Seite"
+      >
+        «
+      </Button>
+      {range.map((item, index) =>
+        item === "…" ? (
+          <span key={`dots_${index}`} className="px-2 text-muted-foreground">
+            …
+          </span>
+        ) : (
+          <Button
+            key={`p_${item}`}
+            variant={item === page ? "default" : "ghost"}
+            className="min-w-9"
+            aria-current={item === page ? "page" : undefined}
+            onClick={() => onPageChange(item)}
+          >
+            {item}
+          </Button>
+        )
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => onPageChange(clamp(page + 1))}
+        disabled={page === totalPages}
+        aria-label="Nächste Seite"
+      >
+        »
+      </Button>
+    </nav>
+  );
+}

--- a/src/components/forum/PostItem.tsx
+++ b/src/components/forum/PostItem.tsx
@@ -11,7 +11,7 @@ interface PostItemProps {
 }
 
 const PostItem = ({ post, author, isOp }: PostItemProps) => (
-  <article className="space-y-3 rounded-2xl border border-border/60 bg-card/70 p-5">
+  <article className="space-y-3 rounded-2xl border border-border/60 bg-card/70 p-5 md:p-6">
     <header className="flex items-center gap-3">
       <Avatar className="h-10 w-10">
         <AvatarImage src={author?.avatarUrl} alt={author?.name} />

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -110,6 +110,14 @@ export interface PaginatedResponse<T> {
   total: number;
 }
 
+export interface PagedResponse<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+}
+
 export interface ThreadWithMeta extends Thread {
   lastPostAt: string;
   lastPosterId: ID;

--- a/src/routes/Thread.tsx
+++ b/src/routes/Thread.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import PageTransition from "@/components/layout/PageTransition";
 import LoadingSkeleton from "@/components/common/LoadingSkeleton";
 import ErrorState from "@/components/common/ErrorState";
@@ -12,65 +12,177 @@ import { formatRelativeTime } from "@/lib/utils/time";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Bell, Flag } from "lucide-react";
+import { Pagination } from "@/components/common/Pagination";
+import { useThreadStore } from "@/store/threadStore";
 
 const Thread = () => {
   const { threadId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawPageParam = Number.parseInt(searchParams.get("page") ?? "1", 10);
+  const requestedPage = Number.isNaN(rawPageParam) ? 1 : Math.max(1, rawPageParam);
+
+  const {
+    posts,
+    loading: postsLoading,
+    page,
+    pageSize,
+    totalPages,
+    totalCount,
+    fetchPage,
+    addPost,
+    lastCreatedPostId
+  } = useThreadStore((state) => ({
+    posts: state.posts,
+    loading: state.loading,
+    page: state.page,
+    pageSize: state.pageSize,
+    totalPages: state.totalPages,
+    totalCount: state.totalCount,
+    fetchPage: state.fetchPage,
+    addPost: state.addPost,
+    lastCreatedPostId: state.lastCreatedPostId
+  }));
+
   const [thread, setThread] = useState<ThreadWithMeta | null>(null);
-  const [posts, setPosts] = useState<Post[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string>();
+  const [threadError, setThreadError] = useState<string>();
+  const [postsError, setPostsError] = useState<string>();
+  const [hasFetchedPosts, setHasFetchedPosts] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  const load = useCallback(async () => {
+  const handlePageChange = useCallback(
+    (next: number) => {
+      setSearchParams({ page: String(next) });
+    },
+    [setSearchParams]
+  );
+
+  const loadThread = useCallback(async () => {
     if (!threadId) return;
     try {
       setLoading(true);
-      const [threadData, postData, userData] = await Promise.all([
+      const [threadData, userData] = await Promise.all([
         mockApi.getThreadById(threadId),
-        mockApi.getPosts(threadId),
         mockApi.getUsers()
       ]);
       if (!threadData) throw new Error("Thread nicht gefunden");
       setThread(threadData);
-      setPosts(postData);
       setUsers(userData);
-      setError(undefined);
+      setThreadError(undefined);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setThreadError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
   }, [threadId]);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    void loadThread();
+  }, [loadThread]);
+
+  useEffect(() => {
+    return () => {
+      useThreadStore.getState().reset();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!threadId) return;
+    setPostsError(undefined);
+    setHasFetchedPosts(false);
+    fetchPage(threadId, requestedPage)
+      .then(() => {
+        setPostsError(undefined);
+        setHasFetchedPosts(true);
+      })
+      .catch((err) => {
+        setPostsError(err instanceof Error ? err.message : String(err));
+        setHasFetchedPosts(true);
+      });
+  }, [threadId, requestedPage, fetchPage]);
+
+  useEffect(() => {
+    // URL-Sync: clamp invalid page parameters and reflect the current page in the query string
+    if (!threadId) return;
+    if (!hasFetchedPosts) return;
+    const effectiveTotal = Math.max(totalPages, totalCount > 0 ? 1 : 0);
+    if (effectiveTotal === 0) {
+      if (requestedPage !== 1) {
+        setSearchParams({ page: "1" }, { replace: true });
+      }
+      return;
+    }
+    const clamped = Math.min(Math.max(requestedPage, 1), totalPages || 1);
+    if (clamped !== requestedPage) {
+      setSearchParams({ page: String(clamped) }, { replace: true });
+    }
+  }, [threadId, requestedPage, totalPages, totalCount, hasFetchedPosts, setSearchParams]);
+
+  useEffect(() => {
+    if (!lastCreatedPostId) return;
+    const element = document.getElementById(`post-${lastCreatedPostId}`);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [lastCreatedPostId]);
 
   const handleSubmit = async ({ body }: { body: string }) => {
     if (!threadId) return;
+    const authorId = users[0]?.id ?? "user-1";
     try {
       setSubmitting(true);
-      const newPost = await mockApi.createPost({ threadId, body, authorId: users[0]?.id ?? "user-1" });
-      setPosts((prev) => [...prev, newPost]);
+      setPostsError(undefined);
+      await addPost(threadId, body, authorId);
+      const { page: lastPage } = useThreadStore.getState();
+      setSearchParams({ page: String(Math.max(1, lastPage)) });
+      setThread((prev) => {
+        if (!prev) return prev;
+        const created = useThreadStore.getState().posts.at(-1);
+        return {
+          ...prev,
+          replies: prev.replies + 1,
+          updatedAt: created?.createdAt ?? prev.updatedAt,
+          lastPostAt: created?.createdAt ?? prev.lastPostAt,
+          lastPosterId: authorId
+        };
+      });
+    } catch (err) {
+      setPostsError(err instanceof Error ? err.message : String(err));
     } finally {
       setSubmitting(false);
     }
   };
+
+  const retryPosts = useCallback(() => {
+    if (!threadId) return;
+    setHasFetchedPosts(false);
+    fetchPage(threadId, requestedPage)
+      .then(() => {
+        setPostsError(undefined);
+        setHasFetchedPosts(true);
+      })
+      .catch((err) => {
+        setPostsError(err instanceof Error ? err.message : String(err));
+        setHasFetchedPosts(true);
+      });
+  }, [threadId, requestedPage, fetchPage]);
 
   const participants = useMemo(() => {
     const ids = new Set(posts.map((post) => post.authorId));
     return users.filter((user) => ids.has(user.id)).slice(0, 6);
   }, [posts, users]);
 
+  const offset = (page - 1) * pageSize;
+
   if (loading && !thread) return <LoadingSkeleton />;
-  if (error) return <ErrorState message={error} onRetry={load} />;
+  if (threadError) return <ErrorState message={threadError} onRetry={loadThread} />;
   if (!thread) return null;
 
   return (
     <PageTransition>
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_260px]">
-        <div className="space-y-4">
+        <div className="space-y-6">
           <header className="space-y-4 rounded-3xl border border-border/60 bg-card/70 p-6">
             <div className="flex flex-wrap items-center justify-between gap-4">
               <div>
@@ -98,18 +210,58 @@ const Thread = () => {
             </div>
           </header>
 
-          <div className="space-y-4">
-            {posts.map((post, index) => (
-              <PostItem
-                key={post.id}
-                post={post}
-                author={users.find((user) => user.id === post.authorId)}
-                isOp={index === 0}
-              />
-            ))}
-          </div>
+          <div className="space-y-6">
+            <div className="space-y-4">
+              {postsLoading && !postsError ? (
+                Array.from({ length: 5 }).map((_, index) => (
+                  <div
+                    key={`skeleton_${index}`}
+                    className="space-y-3 rounded-2xl border border-border/60 bg-card/70 p-5 md:p-6"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="h-10 w-10 rounded-full bg-muted animate-pulse" />
+                      <div className="space-y-2">
+                        <div className="h-3 w-24 rounded-full bg-muted animate-pulse" />
+                        <div className="h-2 w-32 rounded-full bg-muted/80 animate-pulse" />
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="h-3 w-full rounded-full bg-muted/80 animate-pulse" />
+                      <div className="h-3 w-4/5 rounded-full bg-muted/70 animate-pulse" />
+                      <div className="h-3 w-2/3 rounded-full bg-muted/60 animate-pulse" />
+                    </div>
+                  </div>
+                ))
+              ) : postsError ? (
+                <ErrorState message={postsError} onRetry={retryPosts} />
+              ) : totalCount === 0 ? (
+                <div className="rounded-2xl border border-dashed border-border/60 bg-card/50 p-6 text-center text-sm text-muted-foreground">
+                  Noch keine Antworten – sei der/die Erste!
+                </div>
+              ) : (
+                posts.map((post: Post, index) => (
+                  <div id={`post-${post.id}`} key={post.id}>
+                    <PostItem
+                      post={post}
+                      author={users.find((user) => user.id === post.authorId)}
+                      isOp={offset + index === 0}
+                    />
+                  </div>
+                ))
+              )}
+            </div>
 
-          <Composer onSubmit={handleSubmit} isSubmitting={submitting} />
+            <Pagination page={page} totalPages={totalPages || 0} onPageChange={handlePageChange} />
+
+            <div className="space-y-4">
+              <Pagination
+                page={page}
+                totalPages={totalPages || 0}
+                onPageChange={handlePageChange}
+              />
+              <Composer onSubmit={handleSubmit} isSubmitting={submitting} />
+            </div>
+          </div>
         </div>
 
         <aside className="space-y-4">
@@ -119,7 +271,10 @@ const Thread = () => {
             </h2>
             <div className="mt-4 flex flex-wrap gap-3">
               {participants.map((user) => (
-                <div key={user.id} className="flex items-center gap-2 rounded-full border border-border/60 px-3 py-1">
+                <div
+                  key={user.id}
+                  className="flex items-center gap-2 rounded-full border border-border/60 px-3 py-1"
+                >
                   <Avatar className="h-8 w-8">
                     <AvatarImage src={user.avatarUrl} alt={user.name} />
                     <AvatarFallback>{user.name.slice(0, 2)}</AvatarFallback>

--- a/src/store/threadStore.ts
+++ b/src/store/threadStore.ts
@@ -1,0 +1,89 @@
+import { create } from "zustand";
+import type { Post, PagedResponse } from "@/lib/api/types";
+import { getPosts, createPost } from "@/lib/api/mockApi";
+
+const PAGE_SIZE = 5;
+
+type ThreadState = {
+  loading: boolean;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalCount: number;
+  posts: Post[];
+  lastCreatedPostId?: string;
+};
+
+type ThreadActions = {
+  fetchPage: (threadId: string, page: number) => Promise<void>;
+  addPost: (
+    threadId: string,
+    content: string,
+    authorId: string
+  ) => Promise<"navigate-last">;
+  reset: () => void;
+};
+
+export const useThreadStore = create<ThreadState & ThreadActions>((set, get) => ({
+  loading: false,
+  page: 1,
+  pageSize: PAGE_SIZE,
+  totalPages: 1,
+  totalCount: 0,
+  posts: [],
+  lastCreatedPostId: undefined,
+  async fetchPage(threadId, page) {
+    // fetchPage: load posts for the requested page
+    set({ loading: true });
+    try {
+      const res: PagedResponse<Post> = await getPosts(threadId, page, PAGE_SIZE);
+      set({
+        loading: false,
+        posts: res.items,
+        page: res.page,
+        totalPages: res.totalPages,
+        totalCount: res.totalCount,
+        pageSize: res.pageSize,
+        lastCreatedPostId: undefined
+      });
+    } catch (error) {
+      set({ loading: false });
+      throw error;
+    }
+  },
+  async addPost(threadId, content, authorId) {
+    // addPost: create and load the last page
+    set({ loading: true });
+    try {
+      const created = await createPost(threadId, { authorId, content });
+      const nextTotalCount = get().totalCount + 1;
+      const lastPage = Math.max(1, Math.ceil(nextTotalCount / PAGE_SIZE));
+      set({ page: lastPage });
+      const res = await getPosts(threadId, lastPage, PAGE_SIZE);
+      set({
+        loading: false,
+        posts: res.items,
+        page: res.page,
+        totalPages: res.totalPages,
+        totalCount: res.totalCount,
+        pageSize: res.pageSize,
+        lastCreatedPostId: created.id
+      });
+      return "navigate-last";
+    } catch (error) {
+      set({ loading: false });
+      throw error;
+    }
+  },
+  reset() {
+    set({
+      loading: false,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      totalPages: 1,
+      totalCount: 0,
+      posts: [],
+      lastCreatedPostId: undefined
+    });
+  }
+}));


### PR DESCRIPTION
## Summary
- add a dedicated PagedResponse type and paginate the mock API thread posts
- introduce a Zustand thread store and pagination component to drive thread comment views
- update the thread route with URL-synced pagination, loading states, and smooth scrolling for new replies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82065d268832789a3a2badd8c4c3d