### PR TITLE
Avoid refresh attempts without a stored session

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,7 @@ import Login from "@/routes/Auth/Login";
 import Register from "@/routes/Auth/Register";
 import { useUiStore } from "@/store/uiStore";
 import { usePresenceSubscription } from "@/lib/realtime/presence";
-import { useUserStore } from "@/store/userStore";
+import { SESSION_STORAGE_KEY, useUserStore } from "@/store/userStore";
 import { me, refresh } from "@/lib/api/authApi";
 
 const ThemeWatcher = () => {
@@ -54,6 +54,14 @@ const SessionManager = () => {
       return;
     }
     triedRef.current = true;
+
+    if (typeof window !== "undefined") {
+      const hasStoredSession = window.localStorage.getItem(SESSION_STORAGE_KEY);
+      if (!hasStoredSession) {
+        clear();
+        return;
+      }
+    }
 
     let cancelled = false;
 

--- a/apps/web/src/lib/api/authApi.ts
+++ b/apps/web/src/lib/api/authApi.ts
@@ -23,6 +23,9 @@ type RefreshResponse = {
   accessToken: string;
 };
 
+type FetchInput = Parameters<typeof fetch>[0];
+type FetchInit = Parameters<typeof fetch>[1];
+
 async function parseJson<T>(response: Response, errorKey: string): Promise<T> {
   const text = await response.text();
   let payload: unknown;
@@ -92,7 +95,7 @@ export async function logout() {
   });
 }
 
-export async function fetchWithAuth(input: RequestInfo | URL, init: RequestInit = {}) {
+export async function fetchWithAuth(input: FetchInput, init: FetchInit = {}) {
   const { accessToken, setAccessToken, clear } = useUserStore.getState();
 
   const execute = async (token?: string | null) => {

--- a/apps/web/src/routes/Auth/Login.tsx
+++ b/apps/web/src/routes/Auth/Login.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useState } from "react";
+import type { FormEvent } from "react";
+import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import PageTransition from "@/components/layout/PageTransition";

--- a/apps/web/src/routes/Auth/Register.tsx
+++ b/apps/web/src/routes/Auth/Register.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useState } from "react";
+import type { FormEvent } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import PageTransition from "@/components/layout/PageTransition";

--- a/apps/web/src/store/userStore.ts
+++ b/apps/web/src/store/userStore.ts
@@ -2,6 +2,20 @@ import { create } from "zustand";
 
 type Role = "MEMBER" | "ADMIN";
 
+export const SESSION_STORAGE_KEY = "nexuslabs-session";
+
+const setSessionFlag = (value: boolean) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (value) {
+    window.localStorage.setItem(SESSION_STORAGE_KEY, "1");
+  } else {
+    window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  }
+};
+
 export type User = {
   id: string;
   email: string;
@@ -23,7 +37,15 @@ type Actions = {
 export const useUserStore = create<State & Actions>((set) => ({
   user: null,
   accessToken: null,
-  setSession: (user, token) => set({ user, accessToken: token }),
+  setSession: (user, token) =>
+    set(() => {
+      setSessionFlag(true);
+      return { user, accessToken: token };
+    }),
   setAccessToken: (token) => set((state) => ({ ...state, accessToken: token })),
-  clear: () => set({ user: null, accessToken: null })
+  clear: () =>
+    set(() => {
+      setSessionFlag(false);
+      return { user: null, accessToken: null };
+    })
 }));


### PR DESCRIPTION
## Summary
- keep a browser flag for active sessions so refresh is only attempted when a session existed
- sync the local session flag with login/logout state transitions in the user store
- tidy API typings and convert component imports to type-only where required by lint

## Testing
- pnpm --filter nexuslabs-gaming-forum lint

------
https://chatgpt.com/codex/tasks/task_e_68d85128192c8327a2b78da1f2446497