### PR TITLE
Escape hyphen in username validation regex

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -8,7 +8,7 @@ const RegisterSchema = z.object({
     .string()
     .min(3)
     .max(20)
-    .regex(/^[a-zA-Z0-9_-]+$/, "Nur Buchstaben, Zahlen, Unterstrich und Bindestrich erlaubt"),
+    .regex(/^[a-zA-Z0-9_\-]+$/, "Nur Buchstaben, Zahlen, Unterstrich und Bindestrich erlaubt"),
   password: z.string().min(8).max(72)
 });
 

--- a/apps/web/src/routes/Auth/Register.tsx
+++ b/apps/web/src/routes/Auth/Register.tsx
@@ -68,7 +68,7 @@ const Register = () => {
               onChange={(event) => setForm((prev) => ({ ...prev, username: event.target.value }))}
               minLength={3}
               maxLength={20}
-              pattern="^[a-zA-Z0-9_-]+$"
+              pattern="^[a-zA-Z0-9_\\-]+$"
               required
               disabled={loading}
             />


### PR DESCRIPTION
## Summary
- escape the hyphen in the register form username pattern to avoid browser regex errors
- align the API username validation regex with the updated pattern

## Testing
- pnpm --filter nexuslabs-gaming-forum lint

------
https://chatgpt.com/codex/tasks/task_e_68d85d573808832787e879b49573a478