### PR TITLE
Stabilize mock API failures and adjust register validation

### DIFF
--- a/apps/web/.env.local
+++ b/apps/web/.env.local
@@ -1,1 +1,2 @@
 VITE_API_URL="http://localhost:5001"
+VITE_MOCK_FAIL_RATE=0

--- a/apps/web/src/features/auth/validation.ts
+++ b/apps/web/src/features/auth/validation.ts
@@ -1,0 +1,3 @@
+export const USERNAME_REGEX = /^[A-Za-z0-9_-]{3,20}$/u;
+export const USERNAME_PATTERN = "[A-Za-z0-9_\\-]{3,20}";
+export const USERNAME_TITLE = "3–20 Zeichen: Buchstaben, Zahlen, Unterstrich, Bindestrich";

--- a/apps/web/src/routes/Auth/Register.tsx
+++ b/apps/web/src/routes/Auth/Register.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { register } from "@/lib/api/authApi";
 import { useUserStore } from "@/store/userStore";
+import { USERNAME_PATTERN, USERNAME_TITLE } from "@/features/auth/validation";
 
 const Register = () => {
   const navigate = useNavigate();
@@ -68,7 +69,8 @@ const Register = () => {
               onChange={(event) => setForm((prev) => ({ ...prev, username: event.target.value }))}
               minLength={3}
               maxLength={20}
-              pattern="[-A-Za-z0-9_]+"
+              pattern={USERNAME_PATTERN}
+              title={USERNAME_TITLE}
               required
               disabled={loading}
             />

--- a/apps/web/src/routes/Landing.tsx
+++ b/apps/web/src/routes/Landing.tsx
@@ -36,11 +36,30 @@ const Landing = () => {
   useGsapScrollReveal("[data-animate-card]");
 
   useEffect(() => {
-    const fetchStats = async () => {
-      const data = await mockApi.getStats();
-      setStats(data);
+    let alive = true;
+    (async () => {
+      try {
+        const data = await mockApi.getStats();
+        if (alive) {
+          setStats(data);
+        }
+      } catch (e) {
+        console.warn("fetchStats failed", e);
+        if (alive) {
+          setStats({
+            usersTotal: 0,
+            usersOnline: 0,
+            categoriesTotal: 0,
+            threadsTotal: 0,
+            postsTotal: 0,
+            messagesTotal: 0
+          });
+        }
+      }
+    })();
+    return () => {
+      alive = false;
     };
-    void fetchStats();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add environment-driven mock API fail rate with safe defaults and consistent error handling
- harden stats fetching and landing page effect with fallbacks to avoid crashes
- align register username validation rules across inputs and shared constants

## Testing
- pnpm --filter nexuslabs-gaming-forum build

------
https://chatgpt.com/codex/tasks/task_e_68d865c9cdc08327a7edd5b49df62f3e