### PR TITLE
Fix JWT decorators for Fastify access and refresh tokens

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,24 +9,6 @@ import authRoutes from "./routes/auth";
 import usersRoutes from "./routes/users";
 import { errorHandler } from "./errors";
 
-type JwtInstance = {
-  sign: (payload: Record<string, unknown>, options?: Record<string, unknown>) => string;
-  verify: <T = unknown>(token: string, options?: Record<string, unknown>) => T;
-};
-
-declare module "fastify" {
-  interface FastifyInstance {
-    accessJwt: JwtInstance;
-    refreshJwt: JwtInstance;
-  }
-}
-
-declare module "@fastify/jwt" {
-  interface FastifyJWT {
-    payload: Record<string, unknown>;
-  }
-}
-
 const main = async () => {
   const app = Fastify({ logger: true });
 
@@ -44,13 +26,13 @@ const main = async () => {
   await app.register(jwt, {
     secret: env.accessSecret,
     sign: { expiresIn: "10m" },
-    namespace: "access"
+    decoratorName: "accessJwt",
   });
 
   await app.register(jwt, {
     secret: env.refreshSecret,
     sign: { expiresIn: "7d" },
-    namespace: "refresh"
+    decoratorName: "refreshJwt",
   });
 
   await app.register(dbPlugin);

--- a/apps/api/src/types/fastify-jwt.d.ts
+++ b/apps/api/src/types/fastify-jwt.d.ts
@@ -1,0 +1,8 @@
+import "@fastify/jwt";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    accessJwt: import("@fastify/jwt").JWT;
+    refreshJwt: import("@fastify/jwt").JWT;
+  }
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"],
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "src/types/**/*.d.ts"]
 }


### PR DESCRIPTION
## Summary
- register the Fastify JWT plugins with explicit decorator names for access and refresh tokens
- add typings for the JWT decorators and ensure custom type definitions are included in the API tsconfig

## Testing
- npm run build --workspace apps/api

------
https://chatgpt.com/codex/tasks/task_e_68d874e316148327b575b6cb55412c47