### PR TITLE
Refactor API JWT handling to single Fastify instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pnpm dev:web
 ### API (.env)
 
 1. `apps/api/.env.example` kopieren → `apps/api/.env`
-2. `DATABASE_URL`, `JWT_ACCESS_SECRET`, `JWT_REFRESH_SECRET` setzen.
+2. `DATABASE_URL`, `JWT_ACCESS_SECRET` setzen (optional auch `JWT_REFRESH_SECRET`, gleicher Wert).
 3. Migration anlegen (optional lokal): `pnpm --filter nexuslabs-api prisma:migrate`
 
 ### Frontend (.env)

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -3,9 +3,8 @@ import "dotenv/config";
 const required = [
   "DATABASE_URL",
   "JWT_ACCESS_SECRET",
-  "JWT_REFRESH_SECRET",
   "PORT",
-  "CORS_ORIGIN"
+  "CORS_ORIGIN",
 ] as const;
 
 for (const key of required) {
@@ -17,8 +16,7 @@ for (const key of required) {
 export const env = {
   dbUrl: process.env.DATABASE_URL!,
   accessSecret: process.env.JWT_ACCESS_SECRET!,
-  refreshSecret: process.env.JWT_REFRESH_SECRET!,
   port: Number(process.env.PORT ?? 5001),
   origin: process.env.CORS_ORIGIN!,
-  node: process.env.NODE_ENV ?? "development"
+  node: process.env.NODE_ENV ?? "development",
 };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,19 +20,11 @@ const main = async () => {
   });
 
   await app.register(cookie, {
-    hook: "onRequest"
+    hook: "onRequest",
   });
 
   await app.register(jwt, {
     secret: env.accessSecret,
-    sign: { expiresIn: "10m" },
-    decoratorName: "accessJwt",
-  });
-
-  await app.register(jwt, {
-    secret: env.refreshSecret,
-    sign: { expiresIn: "7d" },
-    decoratorName: "refreshJwt",
   });
 
   await app.register(dbPlugin);

--- a/apps/api/src/middlewares/requireAuth.ts
+++ b/apps/api/src/middlewares/requireAuth.ts
@@ -23,7 +23,7 @@ export const createRequireAuth = (app: FastifyInstance) => {
     }
 
     try {
-      const payload = app.accessJwt.verify(token) as { sub: string; role?: Role };
+      const payload = app.jwt.verify(token) as { sub: string; role?: Role };
       request.user = {
         id: payload.sub,
         role: payload.role ?? "MEMBER"

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -105,8 +105,8 @@ const authRoutes: FastifyPluginAsync = async (app) => {
       select: { id: true, email: true, username: true, role: true, createdAt: true },
     });
 
-    const access = app.accessJwt.sign({ sub: user.id, role: user.role });
-    const refresh = app.refreshJwt.sign({ sub: user.id });
+    const access = app.jwt.sign({ sub: user.id, role: user.role }, { expiresIn: "10m" });
+    const refresh = app.jwt.sign({ sub: user.id }, { expiresIn: "7d" });
     setRefresh(reply, refresh);
 
     return reply.send({ user, accessToken: access });
@@ -180,8 +180,8 @@ const authRoutes: FastifyPluginAsync = async (app) => {
         .send({ error: "INVALID_CREDENTIALS", message: "Ungültige Zugangsdaten" });
     }
 
-    const access = app.accessJwt.sign({ sub: user.id, role: user.role });
-    const refresh = app.refreshJwt.sign({ sub: user.id });
+    const access = app.jwt.sign({ sub: user.id, role: user.role }, { expiresIn: "10m" });
+    const refresh = app.jwt.sign({ sub: user.id }, { expiresIn: "7d" });
     setRefresh(reply, refresh);
 
     const { passwordHash, ...safeUser } = user;
@@ -195,7 +195,7 @@ const authRoutes: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const payload = app.refreshJwt.verify(token) as { sub: string };
+      const payload = app.jwt.verify(token) as { sub: string };
       const user = await app.db.user.findUnique({
         where: { id: payload.sub },
         select: { id: true, email: true, username: true, role: true, createdAt: true },
@@ -205,7 +205,7 @@ const authRoutes: FastifyPluginAsync = async (app) => {
         return reply.code(401).send({ error: "NO_USER" });
       }
 
-      const access = app.accessJwt.sign({ sub: user.id, role: user.role });
+      const access = app.jwt.sign({ sub: user.id, role: user.role }, { expiresIn: "10m" });
       return reply.send({ accessToken: access, user });
     } catch (error) {
       if (dbg) {
@@ -229,7 +229,7 @@ const authRoutes: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const payload = app.accessJwt.verify(token) as { sub: string };
+      const payload = app.jwt.verify(token) as { sub: string };
       const user = await app.db.user.findUnique({
         where: { id: payload.sub },
         select: { id: true, email: true, username: true, role: true, createdAt: true },

--- a/apps/api/src/types/fastify-jwt.d.ts
+++ b/apps/api/src/types/fastify-jwt.d.ts
@@ -1,8 +1,0 @@
-import "@fastify/jwt";
-
-declare module "fastify" {
-  interface FastifyInstance {
-    accessJwt: import("@fastify/jwt").JWT;
-    refreshJwt: import("@fastify/jwt").JWT;
-  }
-}


### PR DESCRIPTION
## Summary
- register @fastify/jwt once and configure all routes to use app.jwt for issuing and verifying tokens
- apply per-call access and refresh expirations while simplifying environment configuration to a single JWT secret
- remove redundant Fastify type augmentation now that only app.jwt is used

## Testing
- pnpm --filter nexuslabs-api build

------
https://chatgpt.com/codex/tasks/task_e_68d87689c60483278d08b0d5e3a901b3