### PR TITLE
Implement auth guards and redirect handling

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,8 @@ import { useUiStore } from "@/store/uiStore";
 import { usePresenceSubscription } from "@/lib/realtime/presence";
 import { SESSION_STORAGE_KEY, useUserStore } from "@/store/userStore";
 import { me, refresh } from "@/lib/api/authApi";
+import RequireAuth from "@/components/routing/RequireAuth";
+import RequireGuest from "@/components/routing/RequireGuest";
 
 const ThemeWatcher = () => {
   const theme = useUiStore((state) => state.theme);
@@ -107,9 +109,38 @@ const App = () => {
           <Route path="/forums" element={<Forums />} />
           <Route path="/forum/:categoryId" element={<Category />} />
           <Route path="/thread/:threadId" element={<Thread />} />
-          <Route path="/create" element={<CreatePost />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/register" element={<Register />} />
+          <Route
+            path="/create"
+            element={
+              <RequireAuth>
+                <CreatePost />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/forum/:categoryId/create"
+            element={
+              <RequireAuth>
+                <CreatePost />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/login"
+            element={
+              <RequireGuest>
+                <Login />
+              </RequireGuest>
+            }
+          />
+          <Route
+            path="/register"
+            element={
+              <RequireGuest>
+                <Register />
+              </RequireGuest>
+            }
+          />
         </Routes>
       </AnimatedRoutes>
       <Toaster richColors expand position="top-center" />

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -41,11 +41,12 @@ const Header = () => {
   };
 
   const goToCreate = () => {
-    navigate("/create", { state: { from: location.pathname } });
+    navigate("/create");
   };
 
   const redirectToLogin = () => {
-    navigate("/login", { state: { from: location.pathname } });
+    const redirectTo = encodeURIComponent(location.pathname + location.search);
+    navigate(`/login?redirectTo=${redirectTo}`);
   };
 
   return (

--- a/apps/web/src/components/routing/RequireAuth.tsx
+++ b/apps/web/src/components/routing/RequireAuth.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useUserStore } from "@/store/userStore";
+
+export default function RequireAuth({ children }: { children: ReactElement }) {
+  const user = useUserStore((state) => state.user);
+  const token = useUserStore((state) => state.accessToken);
+  const location = useLocation();
+
+  if (!user || !token) {
+    const redirectTo = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?redirectTo=${redirectTo}`} replace />;
+  }
+
+  return children;
+}

--- a/apps/web/src/components/routing/RequireGuest.tsx
+++ b/apps/web/src/components/routing/RequireGuest.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+import { Navigate, useSearchParams } from "react-router-dom";
+import { useUserStore } from "@/store/userStore";
+
+export default function RequireGuest({ children }: { children: ReactElement }) {
+  const authed = useUserStore((state) => Boolean(state.user && state.accessToken));
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirectTo") || "/forum";
+
+  if (authed) {
+    return <Navigate to={redirect} replace />;
+  }
+
+  return children;
+}

--- a/apps/web/src/routes/Auth/Register.tsx
+++ b/apps/web/src/routes/Auth/Register.tsx
@@ -1,6 +1,6 @@
 import type { FormEvent } from "react";
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import PageTransition from "@/components/layout/PageTransition";
 import { Input } from "@/components/ui/input";
@@ -11,7 +11,9 @@ import { USERNAME_PATTERN, USERNAME_TITLE } from "@/features/auth/validation";
 
 const Register = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const setSession = useUserStore((state) => state.setSession);
+  const redirectParam = searchParams.get("redirectTo");
   const [form, setForm] = useState({ email: "", username: "", password: "" });
   const [loading, setLoading] = useState(false);
 
@@ -22,7 +24,8 @@ const Register = () => {
       const response = await register(form);
       setSession(response.user, response.accessToken);
       toast.success(`Account erstellt! Willkommen, ${response.user.username}.`);
-      navigate("/forum", { replace: true });
+      const redirect = redirectParam || "/forum";
+      navigate(redirect, { replace: true });
     } catch (error) {
       const message = error instanceof Error ? error.message : "register_failed";
       if (message === "USER_EXISTS") {
@@ -95,7 +98,10 @@ const Register = () => {
           </Button>
         </form>
         <p className="text-center text-xs text-muted-foreground">
-          Bereits ein Konto? <Link to="/login" className="text-primary">Login</Link>
+          Bereits ein Konto?{' '}
+          <Link to={redirectParam ? `/login?redirectTo=${encodeURIComponent(redirectParam)}` : "/login"} className="text-primary">
+            Login
+          </Link>
         </p>
       </div>
     </PageTransition>

--- a/apps/web/src/routes/Category.tsx
+++ b/apps/web/src/routes/Category.tsx
@@ -55,7 +55,11 @@ const Category = () => {
             <Button
               className="rounded-xl"
               variant={canPost ? "default" : "outline"}
-              onClick={() => (canPost ? navigate(`/forum/${categoryId}/create`) : navigate("/login", { state: { from: location.pathname } }))}
+              onClick={() =>
+                canPost
+                  ? navigate(`/forum/${categoryId}/create`)
+                  : navigate(`/login?redirectTo=${encodeURIComponent(location.pathname + location.search)}`)
+              }
             >
               {canPost ? "Neuer Thread" : "Login erforderlich"}
             </Button>

--- a/apps/web/src/routes/CreatePost.tsx
+++ b/apps/web/src/routes/CreatePost.tsx
@@ -23,9 +23,10 @@ const CreatePost = () => {
 
   useEffect(() => {
     if (!user) {
-      navigate("/login", { replace: true, state: { from: location.pathname } });
+      const redirectTo = encodeURIComponent(location.pathname + location.search);
+      navigate(`/login?redirectTo=${redirectTo}`, { replace: true });
     }
-  }, [user, navigate, location.pathname]);
+  }, [user, navigate, location.pathname, location.search]);
 
   useEffect(() => {
     if (!categoryId) {

--- a/apps/web/src/store/userStore.ts
+++ b/apps/web/src/store/userStore.ts
@@ -23,7 +23,7 @@ export type User = {
   role: Role;
 };
 
-type State = {
+export type State = {
   user: User | null;
   accessToken: string | null;
 };
@@ -49,3 +49,5 @@ export const useUserStore = create<State & Actions>((set) => ({
       return { user: null, accessToken: null };
     })
 }));
+
+export const isAuthedSelector = (state: State) => Boolean(state.user && state.accessToken);


### PR DESCRIPTION
## Summary
- add Zustand selector helpers and routing guards to centralize auth checks
- update login and registration flows to respect redirectTo query params and store sessions
- wrap protected routes and navigation links so guests are redirected to login before creating content

## Testing
- pnpm --filter nexuslabs-gaming-forum lint

------
https://chatgpt.com/codex/tasks/task_e_68d879fcca3c83278f7918fa6ab0c98d