### PR TITLE
feat: redesign register background animation

### DIFF
--- a/apps/web/src/components/auth/RegisterBackground.tsx
+++ b/apps/web/src/components/auth/RegisterBackground.tsx
@@ -1,96 +1,148 @@
 import { motion } from "framer-motion";
 
-const constellations = [
-  { top: "18%", left: "16%", delay: 0 },
-  { top: "72%", left: "22%", delay: 1.8 },
-  { top: "28%", left: "74%", delay: 2.6 },
-  { top: "64%", left: "70%", delay: 0.9 },
-  { top: "44%", left: "50%", delay: 3.2 },
-  { top: "82%", left: "54%", delay: 4.1 },
+type OrbConfig = {
+  top: string;
+  left: string;
+  size: string;
+  gradient: string;
+  duration: number;
+  delay?: number;
+};
+
+type CometConfig = {
+  top: string;
+  delay: number;
+  duration: number;
+  direction: "left" | "right";
+};
+
+type GlyphConfig = {
+  symbol: string;
+  top: string;
+  left: string;
+  delay: number;
+};
+
+const orbs: OrbConfig[] = [
+  {
+    top: "-10%",
+    left: "-18%",
+    size: "26rem",
+    gradient:
+      "bg-[radial-gradient(circle_at_center,_rgba(59,130,246,0.45),_rgba(12,17,33,0))]",
+    duration: 32,
+  },
+  {
+    top: "18%",
+    left: "55%",
+    size: "32rem",
+    gradient:
+      "bg-[radial-gradient(circle_at_center,_rgba(244,114,182,0.4),_rgba(12,17,33,0))]",
+    duration: 28,
+    delay: 1.2,
+  },
+  {
+    top: "58%",
+    left: "-12%",
+    size: "30rem",
+    gradient:
+      "bg-[radial-gradient(circle_at_center,_rgba(34,197,94,0.35),_rgba(12,17,33,0))]",
+    duration: 36,
+    delay: 2.4,
+  },
+];
+
+const comets: CometConfig[] = [
+  { top: "24%", delay: 0, duration: 14, direction: "right" },
+  { top: "62%", delay: 4.5, duration: 16, direction: "left" },
+  { top: "78%", delay: 2.5, duration: 18, direction: "right" },
+];
+
+const glyphs: GlyphConfig[] = [
+  { symbol: "✶", top: "16%", left: "18%", delay: 0.6 },
+  { symbol: "☉", top: "42%", left: "72%", delay: 1.4 },
+  { symbol: "✧", top: "68%", left: "48%", delay: 0.9 },
+  { symbol: "☾", top: "32%", left: "38%", delay: 1.8 },
+  { symbol: "⚚", top: "58%", left: "14%", delay: 2.4 },
 ];
 
 const RegisterBackground = () => (
   <div className="pointer-events-none absolute inset-0 overflow-hidden">
     <motion.span
-      className="absolute -left-32 top-1/4 h-[28rem] w-[28rem] rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.5),_rgba(12,17,33,0))] blur-3xl"
-      animate={{
-        x: ["0%", "12%", "-18%", "4%", "0%"],
-        y: ["0%", "-10%", "8%", "-6%", "0%"],
-        scale: [1, 1.08, 0.96, 1.05, 1],
-      }}
-      transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
+      className="absolute inset-x-0 top-1/2 h-[42rem] -translate-y-1/2 rounded-[999px] bg-[radial-gradient(circle_at_center,_rgba(15,118,110,0.12),_rgba(12,17,33,0))] blur-[140px]"
+      animate={{ rotate: [0, 15, -8, 0] }}
+      transition={{ duration: 42, repeat: Infinity, ease: "easeInOut" }}
     />
 
-    <motion.span
-      className="absolute -bottom-24 right-0 h-[26rem] w-[26rem] rounded-full bg-[radial-gradient(circle_at_center,_rgba(167,139,250,0.45),_rgba(12,17,33,0))] blur-3xl"
-      animate={{
-        x: ["0%", "-14%", "6%", "-10%", "0%"],
-        y: ["0%", "10%", "-12%", "6%", "0%"],
-        scale: [1, 0.94, 1.06, 0.97, 1],
-      }}
-      transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }}
-    />
-
-    <motion.span
-      className="absolute left-1/3 top-[-12rem] h-[22rem] w-[22rem] rounded-full bg-[conic-gradient(from_140deg_at_50%_50%,_rgba(59,130,246,0.55),_rgba(244,114,182,0.35),_rgba(59,130,246,0.55))] opacity-80 blur-[120px]"
-      animate={{ rotate: [0, 60, 0] }}
-      transition={{ duration: 30, repeat: Infinity, ease: "linear" }}
-    />
-
-    <motion.svg
-      width="640"
-      height="640"
-      viewBox="0 0 640 640"
-      className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 opacity-70"
-    >
-      <defs>
-        <linearGradient id="register-aurora-line" x1="0" y1="0" x2="1" y2="1">
-          <stop offset="0%" stopColor="rgba(56,189,248,0.1)" />
-          <stop offset="50%" stopColor="rgba(56,189,248,0.7)" />
-          <stop offset="100%" stopColor="rgba(244,114,182,0.65)" />
-        </linearGradient>
-      </defs>
-
-      <motion.path
-        d="M120 340 Q200 160 320 220 T540 300"
-        stroke="url(#register-aurora-line)"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        initial={{ pathLength: 0, opacity: 0 }}
-        animate={{ pathLength: [0, 1, 0.25], opacity: [0, 0.9, 0.25] }}
-        transition={{ duration: 16, repeat: Infinity, ease: "easeInOut" }}
-      />
-
-      <motion.path
-        d="M160 420 Q260 520 360 460 T520 420"
-        stroke="url(#register-aurora-line)"
-        strokeWidth="1.2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        initial={{ pathLength: 0, opacity: 0 }}
-        animate={{ pathLength: [0, 0.65, 0], opacity: [0, 0.7, 0] }}
-        transition={{ duration: 18, repeat: Infinity, ease: "easeInOut", delay: 2.4 }}
-      />
-    </motion.svg>
-
-    {constellations.map((constellation, index) => (
+    {orbs.map((orb, index) => (
       <motion.span
-        key={`constellation-${index}`}
-        className="absolute h-2 w-2 rounded-full bg-cyan-300/90 shadow-[0_0_18px_rgba(103,232,249,0.8)]"
-        style={{ top: constellation.top, left: constellation.left }}
-        animate={{ opacity: [0.2, 1, 0.2], scale: [0.8, 1.4, 0.8] }}
-        transition={{ duration: 8, repeat: Infinity, ease: "easeInOut", delay: constellation.delay }}
+        key={`orb-${index}`}
+        className={`absolute ${orb.gradient} blur-3xl`}
+        style={{
+          top: orb.top,
+          left: orb.left,
+          width: orb.size,
+          height: orb.size,
+        }}
+        animate={{
+          x: ["0%", "12%", "-8%", "6%", "0%"],
+          y: ["0%", "-10%", "6%", "-4%", "0%"],
+          scale: [1, 1.12, 0.95, 1.08, 1],
+        }}
+        transition={{
+          duration: orb.duration,
+          repeat: Infinity,
+          ease: "easeInOut",
+          delay: orb.delay ?? 0,
+        }}
+      />
+    ))}
+
+    {comets.map((comet, index) => (
+      <motion.span
+        key={`comet-${index}`}
+        className="absolute h-px w-48 rounded-full bg-gradient-to-r from-transparent via-cyan-200/70 to-cyan-400/0"
+        style={{ top: comet.top }}
+        initial={{
+          x: comet.direction === "right" ? "-20%" : "120%",
+          y: 0,
+          opacity: 0,
+        }}
+        animate={{
+          x: comet.direction === "right" ? ["-20%", "120%"] : ["120%", "-20%"],
+          y: comet.direction === "right" ? ["0%", "-30%"] : ["0%", "30%"],
+          opacity: [0, 1, 0],
+        }}
+        transition={{
+          duration: comet.duration,
+          repeat: Infinity,
+          ease: "easeInOut",
+          delay: comet.delay,
+        }}
+      />
+    ))}
+
+    {glyphs.map((glyph, index) => (
+      <motion.span
+        key={`glyph-${glyph.symbol}-${index}`}
+        className="absolute text-4xl font-light text-cyan-100/40 mix-blend-screen"
+        style={{ top: glyph.top, left: glyph.left }}
+        animate={{
+          y: ["-6%", "6%", "-4%"],
+          rotate: [0, 12, -10, 0],
+          opacity: [0.2, 0.6, 0.35],
+        }}
+        transition={{ duration: 18, repeat: Infinity, ease: "easeInOut", delay: glyph.delay }}
       >
-        <motion.span
-          className="absolute -top-8 left-1/2 h-8 w-px -translate-x-1/2 bg-gradient-to-t from-cyan-300/40 via-transparent to-transparent"
-          animate={{ scaleY: [0.3, 1, 0.6], opacity: [0.1, 0.4, 0.1] }}
-          transition={{ duration: 6, repeat: Infinity, ease: "easeInOut", delay: constellation.delay + 0.6 }}
-        />
+        {glyph.symbol}
       </motion.span>
     ))}
+
+    <motion.span
+      className="absolute right-[-18%] top-[-22%] h-[38rem] w-[38rem] rounded-full bg-[conic-gradient(from_120deg_at_50%_50%,_rgba(56,189,248,0.4),_rgba(244,114,182,0.4),_rgba(34,197,94,0.35),_rgba(56,189,248,0.4))] opacity-70 blur-[130px]"
+      animate={{ rotate: [0, 360] }}
+      transition={{ duration: 68, repeat: Infinity, ease: "linear" }}
+    />
   </div>
 );
 


### PR DESCRIPTION
## Summary
- replace the register background with layered orb, comet, and glyph animations
- introduce reusable config objects to drive motion sequencing and styling
- add ambient gradient wash to tie the animation elements together

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d881083b588327858a845ebd828c99