### PR TITLE
Add handwriting animation to landing page hero text

### DIFF
--- a/apps/web/src/components/HandwritingText.tsx
+++ b/apps/web/src/components/HandwritingText.tsx
@@ -1,0 +1,53 @@
+import { animate, motion, useMotionTemplate, useMotionValue, useTransform } from "framer-motion";
+import { useEffect } from "react";
+import { cn } from "@/lib/utils/cn";
+
+type HandwritingTextProps = {
+  text: string;
+  className?: string;
+  delay?: number;
+};
+
+const HandwritingText = ({ text, className, delay = 0.4 }: HandwritingTextProps) => {
+  const progress = useMotionValue(0);
+  const backgroundSize = useMotionTemplate`${progress}% 100%`;
+  const penLeft = useMotionTemplate`calc(${progress}% - 0.75rem)`;
+  const glowOpacity = useTransform(progress, [0, 35, 100], [0.85, 0.4, 0]);
+  const glowFilter = useMotionTemplate`drop-shadow(0 0 18px rgba(0, 224, 255, ${glowOpacity}))`;
+  const penOpacity = useTransform(progress, [0, 5, 92, 100], [0, 1, 1, 0]);
+
+  useEffect(() => {
+    const controls = animate(progress, 100, {
+      duration: 3.6,
+      ease: [0.35, 0, 0.15, 1],
+      delay
+    });
+
+    return () => {
+      controls.stop();
+    };
+  }, [delay, progress]);
+
+  return (
+    <span className={cn("handwriting relative inline-flex", className)}>
+      <motion.span
+        aria-hidden
+        className="handwriting__text"
+        style={{
+          backgroundSize,
+          filter: glowFilter
+        }}
+      >
+        {text}
+      </motion.span>
+      <span className="sr-only">{text}</span>
+      <motion.span
+        aria-hidden
+        className="handwriting__pen"
+        style={{ left: penLeft, opacity: penOpacity }}
+      />
+    </span>
+  );
+};
+
+export default HandwritingText;

--- a/apps/web/src/routes/Landing.tsx
+++ b/apps/web/src/routes/Landing.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";
 import PageTransition from "@/components/layout/PageTransition";
 import { Button } from "@/components/ui/button";
+import HandwritingText from "@/components/HandwritingText";
 import { Sparkles, ArrowRight, Shield } from "lucide-react";
 import { useGsapScrollReveal } from "@/lib/animations/gsapScroll";
 import { mockApi } from "@/lib/api/mockApi";
@@ -106,7 +107,7 @@ const Landing = () => {
               NexusLabs – The Next-Gen Gaming Forum
             </span>
             <h1 className="text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
-              Verbinde dich mit der Elite der Gaming-Community
+              <HandwritingText text="Verbinde dich mit der Elite der Gaming-Community" />
             </h1>
             <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
               Diskutiere Meta-Strategien, organisiere Scrims und erhalte Insights direkt aus der Szene. Mit Live-Presence, animierten Statistiken und einem Dock-Chat bleibst du immer verbunden.

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -103,3 +103,53 @@ h3 {
 .card-gradient {
   background: linear-gradient(135deg, rgba(0, 224, 255, 0.05), rgba(124, 58, 237, 0.07));
 }
+
+.handwriting {
+  position: relative;
+  isolation: isolate;
+}
+
+.handwriting__text {
+  position: relative;
+  display: inline-block;
+  padding-right: 0.5rem;
+  color: transparent;
+  background-image: linear-gradient(
+    90deg,
+    hsla(var(--foreground), 1) 0%,
+    hsla(var(--foreground), 1) 78%,
+    hsla(var(--foreground), 0.75) 92%,
+    transparent 100%
+  );
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  background-position: left center;
+  -webkit-background-clip: text;
+  background-clip: text;
+  letter-spacing: inherit;
+  white-space: pre-wrap;
+  will-change: background-size, filter;
+  transition: filter 0.4s ease-out;
+}
+
+.handwriting__pen {
+  position: absolute;
+  top: 58%;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 30% 30%, hsla(var(--foreground), 1) 0%, hsla(var(--foreground), 0.6) 65%, transparent 100%);
+  box-shadow: 0 0 18px rgba(0, 224, 255, 0.5);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.handwriting__pen::after {
+  content: "";
+  position: absolute;
+  inset: 55% -30% -35% 45%;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(124, 58, 237, 0.4), rgba(0, 224, 255, 0.3));
+  filter: blur(3px);
+  opacity: 0.75;
+}


### PR DESCRIPTION
## Summary
- add a reusable `HandwritingText` component that animates text with a pen-like motion using framer-motion
- style the handwriting effect and apply it to the landing page hero headline

## Testing
- pnpm --filter nexuslabs-gaming-forum lint

------
https://chatgpt.com/codex/tasks/task_e_68d884222a248327aacd67b9dd18448a