### PR TITLE
Add accessible handwriting headline overlay

### DIFF
--- a/apps/web/src/routes/Landing.tsx
+++ b/apps/web/src/routes/Landing.tsx
@@ -106,8 +106,10 @@ const Landing = () => {
             <span className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs uppercase tracking-wide text-primary">
               NexusLabs – The Next-Gen Gaming Forum
             </span>
-            <h1 className="text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
-              <HandwritingText text="Verbinde dich mit der Elite der Gaming-Community" />
+            <h1 className="mb-6 text-balance">
+              <HandwritingText className="block">
+                Verbinde dich mit der Elite der Gaming-Community
+              </HandwritingText>
             </h1>
             <p className="mx-auto max-w-2xl text-lg text-muted-foreground">
               Diskutiere Meta-Strategien, organisiere Scrims und erhalte Insights direkt aus der Szene. Mit Live-Presence, animierten Statistiken und einem Dock-Chat bleibst du immer verbunden.

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2,6 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Handschrift-Reveal: nutzt eine horizontale Maske, die von 0% → 100% wächst */
+.handwriting-mask {
+  /* CSS-Variable steuert die Breite der Sichtbarkeit */
+  --reveal: 0%;
+  /* Standard-Masken (Chrome/Firefox/Edge) */
+  mask-image: linear-gradient(to right, #000 0 var(--reveal), transparent var(--reveal) 100%);
+  mask-repeat: no-repeat;
+  mask-size: 100% 100%;
+  /* Safari/WebKit */
+  -webkit-mask-image: linear-gradient(to right, #000 0 var(--reveal), transparent var(--reveal) 100%);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: 100% 100%;
+  will-change: mask-image, -webkit-mask-image;
+}
+
 :root {
   color-scheme: dark;
   --background: 222 47% 7%;
@@ -102,54 +117,4 @@ h3 {
 
 .card-gradient {
   background: linear-gradient(135deg, rgba(0, 224, 255, 0.05), rgba(124, 58, 237, 0.07));
-}
-
-.handwriting {
-  position: relative;
-  isolation: isolate;
-}
-
-.handwriting__text {
-  position: relative;
-  display: inline-block;
-  padding-right: 0.5rem;
-  color: transparent;
-  background-image: linear-gradient(
-    90deg,
-    hsla(var(--foreground), 1) 0%,
-    hsla(var(--foreground), 1) 78%,
-    hsla(var(--foreground), 0.75) 92%,
-    transparent 100%
-  );
-  background-repeat: no-repeat;
-  background-size: 0% 100%;
-  background-position: left center;
-  -webkit-background-clip: text;
-  background-clip: text;
-  letter-spacing: inherit;
-  white-space: pre-wrap;
-  will-change: background-size, filter;
-  transition: filter 0.4s ease-out;
-}
-
-.handwriting__pen {
-  position: absolute;
-  top: 58%;
-  width: 1rem;
-  height: 1rem;
-  border-radius: 9999px;
-  background: radial-gradient(circle at 30% 30%, hsla(var(--foreground), 1) 0%, hsla(var(--foreground), 0.6) 65%, transparent 100%);
-  box-shadow: 0 0 18px rgba(0, 224, 255, 0.5);
-  pointer-events: none;
-  transform: translateY(-50%);
-}
-
-.handwriting__pen::after {
-  content: "";
-  position: absolute;
-  inset: 55% -30% -35% 45%;
-  border-radius: 9999px;
-  background: linear-gradient(135deg, rgba(124, 58, 237, 0.4), rgba(0, 224, 255, 0.3));
-  filter: blur(3px);
-  opacity: 0.75;
 }


### PR DESCRIPTION
## Summary
- replace the handwriting headline with a two-layer component that keeps the base text visible and animates an overlay mask via Framer Motion
- add a reusable CSS mask helper that drives the handwriting reveal animation with a --reveal variable
- update the landing page hero to use the new component without blend modes for a high-contrast static headline

## Testing
- pnpm --filter nexuslabs-gaming-forum build

------
https://chatgpt.com/codex/tasks/task_e_68d887f54e6c8327b17d4f0655655c02