### PR TITLE
Fix light mode heading contrast

### DIFF
--- a/apps/web/src/components/TypewriterTitle.tsx
+++ b/apps/web/src/components/TypewriterTitle.tsx
@@ -94,14 +94,15 @@ export default function TypewriterTitle({
         className={clsx(
           "relative z-10 font-extrabold tracking-tight",
           "text-[clamp(32px,6vw,72px)] leading-[1.05]",
-          "text-[#E7F9FF] drop-shadow-[0_2px_20px_rgba(0,200,255,0.15)]"
+          "text-foreground drop-shadow-[0_1px_12px_rgba(56,189,248,0.18)]",
+          "dark:text-[#E7F9FF] dark:drop-shadow-[0_2px_20px_rgba(0,200,255,0.15)]"
         )}
       >
         <span className="pointer-events-none select-none text-transparent whitespace-pre-wrap">
           {text}
         </span>
         <span className="absolute inset-0">
-          <span className="text-[#E7F9FF] whitespace-pre-wrap">
+          <span className="whitespace-pre-wrap text-foreground dark:text-[#E7F9FF]">
             {reduce
               ? text
               : typed.map(({ char, id }) => (


### PR DESCRIPTION
## Summary
- update the typewriter landing title to use theme-aware colors so it remains visible in light mode
- adjust the title drop shadow styling to balance contrast between light and dark themes

## Testing
- pnpm --filter nexuslabs-gaming-forum lint

------
https://chatgpt.com/codex/tasks/task_e_68d893ecbabc83278b769f54723efb81