### PR TITLE
Adjust hero tagline casing

### DIFF
--- a/apps/web/src/components/hero/HeroSection.tsx
+++ b/apps/web/src/components/hero/HeroSection.tsx
@@ -11,7 +11,7 @@ export default function HeroSection() {
       <div className="relative z-10 mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8 py-16 sm:py-20 lg:py-24 text-center">
         <div className="mx-auto mb-5 flex w-max items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold tracking-wide text-cyan-200 shadow-[0_0_20px_rgba(34,211,238,0.15)]">
           <span className="h-1.5 w-1.5 rounded-full bg-cyan-300" aria-hidden />
-          <span>NEXUSLABS – THE NEXT-GEN GAMING FORUM</span>
+          <span>NexusLabs – The Next-Gen Gaming Forum</span>
         </div>
 
         <TypewriterTitle


### PR DESCRIPTION
## Summary
- update the hero badge copy to display "NexusLabs – The Next-Gen Gaming Forum" above the main headline

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d8972922b48327bbbf0e913c7ce51b