### PR TITLE
Fix duplicate keys in TypewriterTitle

### DIFF
--- a/apps/web/src/components/TypewriterTitle.tsx
+++ b/apps/web/src/components/TypewriterTitle.tsx
@@ -107,7 +107,7 @@ export default function TypewriterTitle({
               ? text
               : typed.map(({ char, id }) => (
                   <motion.span
-                    key={id}
+                    key={`${iteration}-${id}`}
                     initial={{ y: "-0.25em", opacity: 0, filter: "blur(6px)" }}
                     animate={{ y: "0em", opacity: 1, filter: "blur(0px)" }}
                     transition={{


### PR DESCRIPTION
## Summary
- ensure TypewriterTitle generates stable, unique keys for each typing iteration to avoid React warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8973e5d88832793a2d8da0464ec8a