### PR TITLE
Fix duplicate keys in typewriter animation

### DIFF
--- a/apps/web/src/components/TypewriterTitle.tsx
+++ b/apps/web/src/components/TypewriterTitle.tsx
@@ -105,9 +105,9 @@ export default function TypewriterTitle({
           <span className="whitespace-pre-wrap text-foreground dark:text-[#E7F9FF]">
             {reduce
               ? text
-              : typed.map(({ char, id }) => (
+              : typed.map(({ char }, index) => (
                   <motion.span
-                    key={`${iteration}-${id}`}
+                    key={`${iteration}-${index}`}
                     initial={{ y: "-0.25em", opacity: 0, filter: "blur(6px)" }}
                     animate={{ y: "0em", opacity: 1, filter: "blur(0px)" }}
                     transition={{


### PR DESCRIPTION
## Summary
- ensure each typewriter character span uses a unique key by basing it on the array index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8983846a48327a75a37b4cfab5356