### PR TITLE
Adjust hero layout for centered badge and content

### DIFF
--- a/apps/web/src/components/hero/HeroSection.tsx
+++ b/apps/web/src/components/hero/HeroSection.tsx
@@ -1,42 +1,57 @@
-import TypewriterTitle from "@/components/TypewriterTitle";
 import { Link } from "react-router-dom";
+import TypewriterTitle from "@/components/TypewriterTitle";
 
 export default function HeroSection() {
   return (
     <section className="relative isolate overflow-hidden rounded-3xl">
+      {/* Background-Layer (Particles etc.) */}
       <div className="pointer-events-none absolute inset-0 z-0">
         {/* <Particles /> */}
       </div>
 
-      <div className="relative z-10 mx-auto flex max-w-[1200px] flex-col items-center px-4 py-16 text-center sm:px-6 sm:py-20 lg:px-8 lg:py-24">
-        <div className="mx-auto mb-5 inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold tracking-wide text-cyan-200 shadow-[0_0_20px_rgba(34,211,238,0.15)]">
-          <span className="h-1.5 w-1.5 rounded-full bg-cyan-300" aria-hidden />
-          <span>NexusLabs – The Next-Gen Gaming Forum</span>
-        </div>
+      {/* Foreground-Content */}
+      <div className="relative z-10 mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8 py-16 sm:py-20 lg:py-24 text-center">
+        {/* === BADGE ÜBER DER ÜBERSCHRIFT === */}
+        <Link
+          to="/forum"
+          className="mx-auto mb-5 inline-flex w-auto items-center gap-2 rounded-full
+                     border border-cyan-400/30 bg-cyan-400/10 px-3 py-1
+                     text-xs font-semibold tracking-wide text-cyan-200
+                     shadow-[0_0_20px_rgba(34,211,238,0.15)]"
+          aria-label="NexusLabs – The Next-Gen Gaming Forum"
+        >
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-cyan-300" />
+          NEXUSLABS – THE NEXT-GEN GAMING FORUM
+        </Link>
 
+        {/* === HEADLINE === */}
         <TypewriterTitle
           text="Verbinde dich mit der Elite der Gaming-Community"
-          className="mx-auto inline-block text-center"
+          className="mx-auto inline-block"
         />
 
+        {/* === SUBCOPY === */}
         <p className="mx-auto mt-6 max-w-[820px] text-base sm:text-lg leading-relaxed text-slate-200/90">
-          Tauche ein in exklusive Diskussionen, sichere dir Early-Access zu brandneuen Titeln
-          und triff die besten Spieler:innen der Szene. Nexuslabs verbindet Leidenschaft,
-          Fortschritt und eine Community, die Gaming ernst nimmt.
+          Diskutiere Meta-Strategien, organisiere Scrims und erhalte Insights direkt
+          aus der Szene. Mit Live-Presence, animierten Statistiken und einem Dock-
+          Chat bleibst du immer verbunden.
         </p>
 
+        {/* === CTAS === */}
         <div className="mt-8 flex items-center justify-center gap-3">
           <Link
-            to="/register"
-            className="inline-flex items-center justify-center rounded-full bg-cyan-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/25 transition hover:bg-cyan-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-300"
+            to="/forum"
+            className="inline-flex items-center justify-center rounded-xl bg-cyan-400/90 px-5 py-3
+                       font-semibold text-slate-900 hover:bg-cyan-300 focus:outline-none focus:ring-2 focus:ring-cyan-300"
           >
-            Jetzt beitreten
+            Forum betreten →
           </Link>
           <Link
-            to="/forum"
-            className="inline-flex items-center justify-center rounded-full border border-cyan-300/40 bg-slate-900/40 px-6 py-3 text-sm font-semibold text-cyan-100 transition hover:border-cyan-300/70 hover:bg-slate-900/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-300"
+            to="/register"
+            className="inline-flex items-center justify-center rounded-xl border border-white/15 px-5 py-3
+                       font-semibold text-slate-100 hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-white/20"
           >
-            Mehr entdecken
+            Konto erstellen
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- center the hero content stack with the new badge link, headline, subcopy, and CTAs
- keep the background layer non-interactive while foreground content remains clickable

## Testing
- Screenshot: hero-update.png

------
https://chatgpt.com/codex/tasks/task_e_68d89b674dc8832796d799e320b9ad71