### PR TITLE
Add availability checks to registration flow

### DIFF
--- a/apps/web/src/features/auth/useAvailability.ts
+++ b/apps/web/src/features/auth/useAvailability.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState } from "react";
+import { checkAvailability } from "@/lib/api/authApi";
+
+export type AvailabilityStatus = "idle" | "loading" | "available" | "taken";
+
+type AvailabilityState = {
+  email: AvailabilityStatus;
+  username: AvailabilityStatus;
+};
+
+export function useAvailability(email: string, username: string, delay = 350) {
+  const [status, setStatus] = useState<AvailabilityState>({ email: "idle", username: "idle" });
+  const timer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+
+    if (!email && !username) {
+      setStatus({ email: "idle", username: "idle" });
+      return undefined;
+    }
+
+    setStatus({
+      email: email ? "loading" : "idle",
+      username: username ? "loading" : "idle",
+    });
+
+    let cancelled = false;
+
+    const handle = window.setTimeout(async () => {
+      try {
+        const response = await checkAvailability({
+          email: email || undefined,
+          username: username || undefined,
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        setStatus({
+          email: response.email === "skip" ? "idle" : response.email,
+          username: response.username === "skip" ? "idle" : response.username,
+        });
+      } catch {
+        if (cancelled) {
+          return;
+        }
+
+        setStatus((current) => ({
+          email: current.email === "loading" ? "idle" : current.email,
+          username: current.username === "loading" ? "idle" : current.username,
+        }));
+      }
+    }, delay);
+
+    timer.current = handle;
+
+    return () => {
+      cancelled = true;
+      if (timer.current !== null) {
+        window.clearTimeout(timer.current);
+        timer.current = null;
+      }
+    };
+  }, [email, username, delay]);
+
+  const invalid = status.email === "taken" || status.username === "taken";
+  const loading = status.email === "loading" || status.username === "loading";
+
+  return { status, invalid, loading };
+}

--- a/apps/web/src/lib/api/authApi.ts
+++ b/apps/web/src/lib/api/authApi.ts
@@ -56,6 +56,31 @@ export async function register(data: { email: string; username: string; password
   return jsonOrThrow<AuthResponse>(response);
 }
 
+export async function checkAvailability(payload: { email?: string; username?: string }) {
+  const res = await fetch(`${API}/auth/availability`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(payload)
+  });
+
+  const data = (await res
+    .json()
+    .catch(() => ({}))) as { message?: unknown; email?: unknown; username?: unknown };
+
+  if (!res.ok) {
+    const message = typeof data.message === "string" && data.message.length > 0
+      ? data.message
+      : "Verfügbarkeitsprüfung fehlgeschlagen";
+    throw new Error(message);
+  }
+
+  return data as {
+    email: "available" | "taken" | "skip";
+    username: "available" | "taken" | "skip";
+  };
+}
+
 export async function login(data: { emailOrUsername: string; password: string }) {
   const response = await fetch(`${API}/auth/login`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- add a POST /auth/availability endpoint that normalizes credentials before checking for duplicates
- provide a client helper and debounced React hook to query the new endpoint
- surface inline availability feedback in the registration form and prevent submits while a value is taken

## Testing
- pnpm --filter nexuslabs-api build
- pnpm --filter nexuslabs-gaming-forum lint

------
https://chatgpt.com/codex/tasks/task_e_68d8a3ec418883279ba0096740bc6af0