### PR TITLE
Fix user profile update relation handling

### DIFF
--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -614,7 +614,9 @@ const usersRoutes: FastifyPluginAsync = async (app) => {
         userUpdate.birthday = body.birthday ? new Date(body.birthday) : null;
       }
       if (profileData) {
-        userUpdate.profile = profileData;
+        userUpdate.profile = {
+          upsert: profileData,
+        } as never;
       }
 
       if (body.notifications) {


### PR DESCRIPTION
## Summary
- wrap the user profile mutation in an upsert when updating users so Prisma keeps the UserToUserProfile relation intact

## Testing
- pnpm --filter nexuslabs-api build *(fails: existing TypeScript errors in auth and user routes unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d91eb5eeac832783857c76fe8ed4f7