### PR TITLE
Fix duplicate at sign in profile header

### DIFF
--- a/apps/web/src/routes/Profile.tsx
+++ b/apps/web/src/routes/Profile.tsx
@@ -662,7 +662,8 @@ const renderMetadataItem = (
               </div>
               <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
                 <span className="flex items-center gap-1">
-                  <AtSign className="h-4 w-4" />@{profile.handle}
+                  <AtSign className="h-4 w-4" />
+                  {profile.handle}
                 </span>
                 {profile.contact.pronouns ? (
                   <span className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- remove the duplicated at sign in the profile header handle display so it only shows a single @ symbol

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d92a8f7c688327b71f0bfdaf3ae55c