### PR TITLE
Add automated badge assignment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ nexuslabs/
 - 🌗 Dark Mode standardmäßig aktiv, Light Mode Toggle mit Persistenz.
 - 🧹 ESLint + Prettier Konfiguration für sauberen TypeScript-Code.
 
+## Badge-Orchestrierung
+
+- Alle offiziellen NexusLabs-Badges werden automatisch über deklarative Regeln in `apps/api/src/badges/rules.ts` vergeben.
+- Die Evaluierung lädt alle benötigten Benutzer-, Statistik- und Legacy-Informationen gebündelt und erzeugt idempotente `UserBadge`-Upserts.
+- Ein interner Endpoint (`POST /internal/badges/recompute`) stößt die Vergabe für einzelne Nutzer (`userId`), Listen (`userIds`) oder alle Accounts (`{"all": true}`) an.
+- Bestehende Auszeichnungen werden in einer Transaktion aktualisiert, veraltete Einträge optional widerrufen und mit `revokedAt` markiert.
+- Tests (Vitest) für Badge-Regeln und Orchestrierung laufen via `pnpm --filter nexuslabs-api test`.
+
+### Neue Badge-Regeln hinzufügen
+
+1. Eine neue Regel im Array `badgeRules` anlegen und Kriterien, Priorität und optionale Saison definieren.
+2. Falls zusätzliche Daten benötigt werden, diese im Evaluator (`apps/api/src/badges/evaluator.ts`) bündeln oder über `context.useCache` laden.
+3. Optional Unit-Tests ergänzen (`apps/api/test/badges`).
+4. Recompute ausführen (`POST /internal/badges/recompute`) oder lokal mit Dry-Run (`{"dryRun": true}`) testen.
+
 ## Getting Started
 
 ```bash

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
     "start": "node dist/index.js",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fastify/cookie": "9.4.0",
@@ -26,6 +27,7 @@
     "@types/node": "^20",
     "prisma": "^6.16.2",
     "tsx": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/api/prisma/migrations/20240720120000_add_userbadge_metadata/migration.sql
+++ b/apps/api/prisma/migrations/20240720120000_add_userbadge_metadata/migration.sql
@@ -1,0 +1,9 @@
+-- Add metadata fields to UserBadge for badge pipeline
+ALTER TABLE "UserBadge"
+  ADD COLUMN IF NOT EXISTS "earnedReason" TEXT,
+  ADD COLUMN IF NOT EXISTS "revokedAt" TIMESTAMP(3);
+
+-- Ensure existing revoked entries default to null state
+UPDATE "UserBadge"
+SET "revokedAt" = NULL
+WHERE "revokedAt" IS NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -208,6 +208,8 @@ model UserBadge {
   earnedAt  DateTime @default(now())
   seasonKey String?
   note      String?
+  earnedReason String?
+  revokedAt    DateTime?
 
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
   badge Badge @relation(fields: [badgeId], references: [id], onDelete: Cascade)

--- a/apps/api/src/badges/assignment.ts
+++ b/apps/api/src/badges/assignment.ts
@@ -1,0 +1,191 @@
+import type { PrismaClient, Prisma } from "@prisma/client";
+import { BadgeEvaluator } from "./evaluator";
+import badgeRules from "./rules";
+import type {
+  BadgeAssignmentResult,
+  BadgeAssignmentSummary,
+  BadgeRevocationSummary,
+  BadgeRule,
+} from "./types";
+
+export type RecomputeOptions = {
+  userIds?: string[];
+  dryRun?: boolean;
+  now?: Date;
+};
+
+export type BadgeRecomputeResult = {
+  dryRun: boolean;
+  assignments: BadgeAssignmentResult[];
+  summaries: BadgeAssignmentSummary[];
+  revocations: BadgeRevocationSummary[];
+};
+
+const assignmentKey = (userId: string, slug: string, seasonKey: string | null) =>
+  `${userId}:${slug}:${seasonKey ?? "_"}`;
+
+export class BadgeAssignmentOrchestrator {
+  private readonly evaluator: BadgeEvaluator;
+  private readonly rulesBySlug: Map<string, BadgeRule[]>;
+
+  constructor(private readonly prisma: PrismaClient) {
+    this.evaluator = new BadgeEvaluator(prisma);
+    this.rulesBySlug = badgeRules.reduce((map, rule) => {
+      const existing = map.get(rule.badgeSlug) ?? [];
+      existing.push(rule);
+      map.set(rule.badgeSlug, existing);
+      return map;
+    }, new Map<string, BadgeRule[]>());
+  }
+
+  async recompute(options: RecomputeOptions = {}): Promise<BadgeRecomputeResult> {
+    const { assignments } = await this.evaluator.evaluate({
+      userIds: options.userIds,
+      now: options.now,
+    });
+    const dryRun = options.dryRun ?? false;
+    const effectiveNow = options.now ?? new Date();
+
+    const userIds = new Set<string>();
+    assignments.forEach((assignment) => userIds.add(assignment.userId));
+    if (options.userIds) {
+      options.userIds.forEach((id) => userIds.add(id));
+    }
+
+    const targetIds = Array.from(userIds);
+    if (targetIds.length === 0) {
+      return { dryRun, assignments, summaries: [], revocations: [] };
+    }
+
+    const badges = await this.prisma.badge.findMany({
+      select: { id: true, slug: true },
+    });
+    const badgeBySlug = new Map(badges.map((badge) => [badge.slug, badge]));
+
+    const currentAwards = await this.prisma.userBadge.findMany({
+      where: { userId: { in: targetIds } },
+      select: {
+        id: true,
+        userId: true,
+        badgeId: true,
+        earnedAt: true,
+        seasonKey: true,
+        note: true,
+        earnedReason: true,
+        revokedAt: true,
+        badge: { select: { slug: true } },
+      },
+    });
+
+    const currentByKey = new Map<string, (typeof currentAwards)[number]>();
+    currentAwards.forEach((award) => {
+      const key = assignmentKey(award.userId, award.badge.slug, award.seasonKey);
+      currentByKey.set(key, award);
+    });
+
+    const summaries: BadgeAssignmentSummary[] = [];
+    const revocations: BadgeRevocationSummary[] = [];
+    const assignmentMap = new Map<string, BadgeAssignmentResult>();
+    const createOperations: Prisma.UserBadgeCreateArgs[] = [];
+    const updateOperations: Prisma.UserBadgeUpdateArgs[] = [];
+    const revokeOperations: Prisma.UserBadgeUpdateArgs[] = [];
+
+    for (const assignment of assignments) {
+      const badge = badgeBySlug.get(assignment.badgeSlug);
+      if (!badge) {
+        throw new Error(`Badge with slug ${assignment.badgeSlug} not found.`);
+      }
+      const key = assignmentKey(assignment.userId, assignment.badgeSlug, assignment.seasonKey);
+      assignmentMap.set(key, assignment);
+      const existing = currentByKey.get(key);
+      const change: BadgeAssignmentSummary["change"] = existing
+        ? existing.revokedAt
+          ? "restored"
+          : "updated"
+        : "created";
+
+      const needsUpdate = !existing
+        ? true
+        : existing.revokedAt !== null ||
+          existing.earnedAt.getTime() !== assignment.earnedAt.getTime() ||
+          (existing.note ?? null) !== (assignment.note ?? null) ||
+          (existing.earnedReason ?? null) !== (assignment.earnedReason ?? null);
+
+      if (!needsUpdate) {
+        summaries.push({
+          slug: assignment.badgeSlug,
+          userId: assignment.userId,
+          seasonKey: assignment.seasonKey ?? null,
+          change: "noop",
+        });
+        continue;
+      }
+
+      summaries.push({
+        slug: assignment.badgeSlug,
+        userId: assignment.userId,
+        seasonKey: assignment.seasonKey ?? null,
+        change,
+      });
+
+      if (!existing) {
+        createOperations.push({
+          data: {
+            userId: assignment.userId,
+            badgeId: badge.id,
+            seasonKey: assignment.seasonKey ?? undefined,
+            earnedAt: assignment.earnedAt,
+            note: assignment.note,
+            earnedReason: assignment.earnedReason,
+            revokedAt: null,
+          },
+        });
+      } else {
+        updateOperations.push({
+          where: { id: existing.id },
+          data: {
+            earnedAt: assignment.earnedAt,
+            note: assignment.note,
+            earnedReason: assignment.earnedReason,
+            revokedAt: null,
+          },
+        });
+      }
+    }
+
+    for (const award of currentAwards) {
+      const key = assignmentKey(award.userId, award.badge.slug, award.seasonKey);
+      if (assignmentMap.has(key)) continue;
+      if (award.revokedAt) continue;
+      const rules = this.rulesBySlug.get(award.badge.slug) ?? [];
+      const allowsRevocation = rules.every((rule) => rule.allowRevocation !== false);
+      if (!allowsRevocation) continue;
+
+      revocations.push({
+        userId: award.userId,
+        badgeSlug: award.badge.slug,
+        seasonKey: award.seasonKey ?? null,
+        userBadgeId: award.id,
+      });
+
+      revokeOperations.push({
+        where: { id: award.id },
+        data: {
+          revokedAt: effectiveNow,
+          earnedReason:
+            award.earnedReason ?? "Automatische Aberkennung aufgrund fehlender Kriterien.",
+        },
+      });
+    }
+
+    if (!dryRun && (createOperations.length > 0 || updateOperations.length > 0 || revokeOperations.length > 0)) {
+      await this.prisma.$transaction([
+        ...createOperations.map((args) => this.prisma.userBadge.create(args)),
+        ...updateOperations.map((args) => this.prisma.userBadge.update(args)),
+        ...revokeOperations.map((args) => this.prisma.userBadge.update(args)),
+      ]);
+    }
+
+    return { dryRun, assignments, summaries, revocations };
+  }
+}

--- a/apps/api/src/badges/evaluator.ts
+++ b/apps/api/src/badges/evaluator.ts
@@ -1,0 +1,231 @@
+import type { PrismaClient, Prisma } from "@prisma/client";
+import badgeRules from "./rules";
+import type {
+  BadgeAssignmentResult,
+  BadgeCandidate,
+  BadgeEvaluationContext,
+  BadgeRule,
+  CandidateProfileDetails,
+  CandidateStats,
+} from "./types";
+import { extractProfileBadges } from "../profile/badges";
+import { parseJsonArray } from "../utils/json";
+
+const DEFAULT_PRIORITY = 100;
+
+const createProfileDetails = (user: {
+  username: string;
+  displayName: string | null;
+  bio: string | null;
+  profile: {
+    about: string | null;
+    interests: string | null;
+    socials: Prisma.JsonValue | null;
+    links: Prisma.JsonValue | null;
+    badges: Prisma.JsonValue | null;
+    bio: string | null;
+  } | null;
+}): CandidateProfileDetails | null => {
+  if (!user.profile) {
+    return {
+      hasDisplayName: Boolean(user.displayName && user.displayName !== user.username),
+      hasBio: Boolean(user.bio),
+      aboutLength: 0,
+      socialsCount: 0,
+      linksCount: 0,
+      interestsLength: 0,
+      legacyOfficial: new Map(),
+    };
+  }
+
+  const aboutLength = (user.profile.about ?? "").length;
+  const interestsLength = (user.profile.interests ?? "").length;
+  const socialsCount = parseJsonArray<unknown>(user.profile.socials).length;
+  const linksCount = parseJsonArray<unknown>(user.profile.links).length;
+  const { legacyOfficial } = extractProfileBadges(user.profile.badges ?? null);
+
+  return {
+    hasDisplayName: Boolean(user.displayName && user.displayName !== user.username),
+    hasBio: Boolean(user.bio ?? user.profile.about ?? user.profile.bio ?? undefined),
+    aboutLength,
+    socialsCount,
+    linksCount,
+    interestsLength,
+    legacyOfficial,
+  };
+};
+
+const mapStats = (stats: {
+  topics: number;
+  posts: number;
+  likesGiven: number;
+  likesReceived: number;
+  reputation: number;
+  trustLevel: string;
+  streakDays: number;
+  longestStreak: number;
+  lastActiveAt: Date | null;
+} | null): CandidateStats | null => {
+  if (!stats) return null;
+  return {
+    topics: stats.topics,
+    posts: stats.posts,
+    likesGiven: stats.likesGiven,
+    likesReceived: stats.likesReceived,
+    reputation: stats.reputation,
+    trustLevel: stats.trustLevel as CandidateStats["trustLevel"],
+    streakDays: stats.streakDays,
+    longestStreak: stats.longestStreak,
+    lastActiveAt: stats.lastActiveAt,
+  };
+};
+
+export const runBadgeRules = async (
+  rules: BadgeRule[],
+  context: BadgeEvaluationContext
+): Promise<BadgeAssignmentResult[]> => {
+  const sorted = [...rules].sort(
+    (a, b) => (a.priority ?? DEFAULT_PRIORITY) - (b.priority ?? DEFAULT_PRIORITY)
+  );
+  const map = new Map<string, BadgeAssignmentResult>();
+
+  for (const rule of sorted) {
+    const grants = await rule.evaluate(context);
+    if (!Array.isArray(grants) || grants.length === 0) continue;
+    for (const grant of grants) {
+      if (context.targetUserIds && !context.targetUserIds.has(grant.userId)) {
+        continue;
+      }
+      const seasonKey = grant.seasonKey ?? rule.seasonKey ?? null;
+      const key = `${grant.userId}:${rule.badgeSlug}:${seasonKey ?? "_"}`;
+      const priority = rule.priority ?? DEFAULT_PRIORITY;
+      const existing = map.get(key);
+      if (existing && existing.priority <= priority) {
+        continue;
+      }
+      map.set(key, {
+        userId: grant.userId,
+        badgeSlug: rule.badgeSlug,
+        seasonKey,
+        earnedAt: grant.earnedAt ?? context.now,
+        note: grant.note ?? null,
+        earnedReason: grant.reason ?? rule.defaultReason ?? rule.description,
+        priority,
+        allowRevocation: rule.allowRevocation ?? true,
+        ruleId: rule.id,
+      });
+    }
+  }
+
+  return Array.from(map.values());
+};
+
+const createContext = (
+  prisma: PrismaClient,
+  candidates: BadgeCandidate[],
+  now: Date,
+  targetUserIds: Set<string> | null
+): BadgeEvaluationContext => {
+  const cache = new Map<string, unknown>();
+  return {
+    prisma,
+    candidates,
+    now,
+    targetUserIds,
+    cache,
+    async useCache<T>(key: string, loader: () => Promise<T>): Promise<T> {
+      if (cache.has(key)) {
+        return cache.get(key) as T;
+      }
+      const value = await loader();
+      cache.set(key, value);
+      return value;
+    },
+  };
+};
+
+export class BadgeEvaluator {
+  private readonly rules: BadgeRule[];
+  constructor(private readonly prisma: PrismaClient, rules: BadgeRule[] = badgeRules) {
+    this.rules = rules;
+  }
+
+  async loadCandidates(userIds?: string[]): Promise<BadgeCandidate[]> {
+    const users = await this.prisma.user.findMany({
+      where: userIds && userIds.length > 0 ? { id: { in: userIds } } : undefined,
+      select: {
+        id: true,
+        username: true,
+        createdAt: true,
+        role: true,
+        displayName: true,
+        bio: true,
+        stats: {
+          select: {
+            topics: true,
+            posts: true,
+            likesGiven: true,
+            likesReceived: true,
+            reputation: true,
+            trustLevel: true,
+            streakDays: true,
+            longestStreak: true,
+            lastActiveAt: true,
+          },
+        },
+        profile: {
+          select: {
+            about: true,
+            interests: true,
+            socials: true,
+            links: true,
+            badges: true,
+            bio: true,
+          },
+        },
+        connectedAccounts: {
+          select: {
+            provider: true,
+            verified: true,
+          },
+        },
+        _count: {
+          select: {
+            followers: true,
+            following: true,
+          },
+        },
+      },
+    });
+
+    return users.map((user) => {
+      const profile: CandidateProfileDetails | null = createProfileDetails(user);
+      const stats: CandidateStats | null = mapStats(user.stats);
+      return {
+        id: user.id,
+        username: user.username,
+        createdAt: user.createdAt,
+        role: user.role,
+        stats,
+        profile,
+        connectedAccounts: user.connectedAccounts.map((account) => ({
+          provider: account.provider,
+          verified: account.verified,
+        })),
+        followerCount: user._count.followers,
+        followingCount: user._count.following,
+      } satisfies BadgeCandidate;
+    });
+  }
+
+  async evaluate(options: { userIds?: string[]; now?: Date } = {}) {
+    const { userIds, now = new Date() } = options;
+    const candidates = await this.loadCandidates(userIds);
+    const targetUserIds = userIds && userIds.length > 0 ? new Set(userIds) : null;
+    const context = createContext(this.prisma, candidates, now, targetUserIds);
+    const assignments = await runBadgeRules(this.rules, context);
+    return { assignments, candidates, context };
+  }
+}
+
+export type BadgeEvaluationOutput = Awaited<ReturnType<BadgeEvaluator["evaluate"]>>;

--- a/apps/api/src/badges/rules.ts
+++ b/apps/api/src/badges/rules.ts
@@ -1,0 +1,364 @@
+import { TrustLevel } from "@prisma/client";
+import { KNOWN_OFFICIAL_BADGES } from "../profile/badges";
+import type { BadgeRule, BadgeGrant, BadgeEvaluationContext, BadgeCandidate } from "./types";
+
+const trustOrder: Record<TrustLevel, number> = {
+  NEWCOMER: 0,
+  MEMBER: 1,
+  CONTRIBUTOR: 2,
+  VETERAN: 3,
+  MODERATOR: 4,
+  ADMINISTRATOR: 5,
+};
+
+const hasMinimumTrust = (candidate: BadgeCandidate, min: TrustLevel) => {
+  const candidateLevel = candidate.stats?.trustLevel ?? TrustLevel.NEWCOMER;
+  return trustOrder[candidateLevel] >= trustOrder[min];
+};
+
+const withTarget = (context: BadgeEvaluationContext, candidate: BadgeCandidate) => {
+  if (!context.targetUserIds) return true;
+  return context.targetUserIds.has(candidate.id);
+};
+
+const makeGrants = (
+  context: BadgeEvaluationContext,
+  predicate: (candidate: BadgeCandidate) => boolean,
+  options?: { note?: string; reason?: string; earnedAt?: (candidate: BadgeCandidate) => Date }
+): BadgeGrant[] => {
+  const { note, reason, earnedAt } = options ?? {};
+  return context.candidates
+    .filter((candidate) => withTarget(context, candidate) && predicate(candidate))
+    .map((candidate) => ({
+      userId: candidate.id,
+      note: note ?? null,
+      reason: reason ?? null,
+      earnedAt: earnedAt ? earnedAt(candidate) : candidate.createdAt,
+    }));
+};
+
+const primaryRules: BadgeRule[] = [
+  {
+    id: "core-team.role",
+    badgeSlug: "core-team",
+    description: "Vergeben an Mitglieder des Administrationskerns.",
+    defaultReason: "Mitglied des NexusLabs Kernteams.",
+    priority: 10,
+    evaluate: async (context) =>
+      makeGrants(context, (candidate) => candidate.role === "ADMIN", {
+        reason: "User besitzt Administratorrechte und gehört zum Kernteam.",
+      }),
+  },
+  {
+    id: "operations-lead.trust",
+    badgeSlug: "operations-lead",
+    description: "Leitet operative Prozesse und hat Administrator-Vertrauensstufe.",
+    defaultReason: "Operative Leitungsverantwortung bestätigt.",
+    priority: 20,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) =>
+          candidate.role === "ADMIN" && hasMinimumTrust(candidate, TrustLevel.ADMINISTRATOR),
+        {
+          reason: "Vertrauensstufe ADMINISTRATOR bestätigt operative Leitungsrolle.",
+        }
+      ),
+  },
+  {
+    id: "founder.first-users",
+    badgeSlug: "founder",
+    description: "Erste Gründungsmitglieder der Plattform.",
+    defaultReason: "Zu den frühesten NexusLabs Accounts gezählt.",
+    priority: 30,
+    evaluate: async (context) => {
+      const founderSet = await context.useCache("badges:founder:set", async () => {
+        const earliest = await context.prisma.user.findMany({
+          orderBy: { createdAt: "asc" },
+          take: 5,
+          select: { id: true },
+        });
+        return new Set(earliest.map((entry) => entry.id));
+      });
+
+      return makeGrants(
+        context,
+        (candidate) => founderSet.has(candidate.id),
+        {
+          reason: "Gehört zu den ersten fünf registrierten Mitgliedern.",
+        }
+      );
+    },
+  },
+  {
+    id: "early-adopter.first-100",
+    badgeSlug: "early-adopter",
+    description: "Frühe Unterstützerinnen und Unterstützer in der Aufbauphase.",
+    defaultReason: "Unter den ersten 100 Mitgliedern der Community.",
+    priority: 40,
+    evaluate: async (context) => {
+      const adopterSet = await context.useCache("badges:early:set", async () => {
+        const earliest = await context.prisma.user.findMany({
+          orderBy: { createdAt: "asc" },
+          take: 100,
+          select: { id: true },
+        });
+        return new Set(earliest.map((entry) => entry.id));
+      });
+
+      return makeGrants(
+        context,
+        (candidate) => adopterSet.has(candidate.id),
+        {
+          reason: "Zählt zu den ersten hundert registrierten Accounts.",
+        }
+      );
+    },
+  },
+  {
+    id: "verified.connected-account",
+    badgeSlug: "verified",
+    description: "Identität oder Social-Profil wurde überprüft.",
+    defaultReason: "Mindestens ein verifiziertes verbundenes Konto vorhanden.",
+    priority: 50,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => candidate.connectedAccounts.some((account) => account.verified),
+        {
+          reason: "Verifiziertes Drittanbieter-Konto hinterlegt.",
+        }
+      ),
+  },
+  {
+    id: "community-champion.engagement",
+    badgeSlug: "community-champion",
+    description: "Vorbildliche Aktivität und Community-Engagement.",
+    defaultReason: "Hohe Aktivität und viel positives Feedback in der Community.",
+    priority: 60,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const stats = candidate.stats;
+          if (!stats) return false;
+          return (
+            stats.likesGiven >= 200 &&
+            stats.likesReceived >= 250 &&
+            candidate.followerCount >= 5 &&
+            hasMinimumTrust(candidate, TrustLevel.VETERAN)
+          );
+        },
+        {
+          reason: "Hohe Zahl an erhaltenen Likes und aktive Community-Unterstützung.",
+        }
+      ),
+  },
+  {
+    id: "top-poster.volume",
+    badgeSlug: "top-poster",
+    description: "Aktivste Verfasser:innen von Beiträgen.",
+    defaultReason: "Mehr als 200 Beiträge veröffentlicht.",
+    priority: 70,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => (candidate.stats?.posts ?? 0) >= 200,
+        {
+          reason: "Mindestens 200 veröffentlichte Beiträge.",
+        }
+      ),
+  },
+  {
+    id: "knowledge-sharer.guides",
+    badgeSlug: "knowledge-sharer",
+    description: "Teilt regelmäßig Wissen und hilfreiche Themen.",
+    defaultReason: "Viele Themen eröffnet und positives Feedback erhalten.",
+    priority: 80,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const stats = candidate.stats;
+          if (!stats) return false;
+          return stats.topics >= 25 && stats.likesReceived >= 150;
+        },
+        {
+          reason: "Mindestens 25 Themen mit über 150 erhaltenen Likes.",
+        }
+      ),
+  },
+  {
+    id: "event-champion.legacy",
+    badgeSlug: "event-champion",
+    description: "Gewinner:innen von NexusLabs Community-Events.",
+    defaultReason: "Event-Sieg laut bestehenden Auszeichnungen.",
+    seasonKey: "community-events",
+    priority: 90,
+    allowRevocation: false,
+    evaluate: async (context) => {
+      const awards = await context.useCache("badges:event-champion:existing", async () => {
+        const entries = await context.prisma.userBadge.findMany({
+          where: {
+            revokedAt: null,
+            badge: { slug: "event-champion" },
+          },
+          select: { userId: true, earnedAt: true, note: true, seasonKey: true },
+        });
+        return entries;
+      });
+
+      const userIds = new Set(context.candidates.map((candidate) => candidate.id));
+      return awards
+        .filter((award) => userIds.has(award.userId))
+        .map((award) => ({
+          userId: award.userId,
+          seasonKey: award.seasonKey ?? "community-events",
+          earnedAt: award.earnedAt ?? context.now,
+          note: award.note ?? null,
+          reason: "Aus vorherigem Event-Sieg übernommen.",
+        }));
+    },
+  },
+  {
+    id: "bug-hunter.reports",
+    badgeSlug: "bug-hunter",
+    description: "Hilft aktiv bei technischen Tests und meldet Bugs.",
+    defaultReason: "Verifiziertes Entwicklerkonto oder hohe Reputation.",
+    priority: 100,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const stats = candidate.stats;
+          const hasGithub = candidate.connectedAccounts.some(
+            (account) => account.provider === "GITHUB" && account.verified
+          );
+          return hasGithub || (stats?.reputation ?? 0) >= 350;
+        },
+        {
+          reason: "Verifiziertes Entwicklerkonto oder Reputation über 350.",
+        }
+      ),
+  },
+  {
+    id: "helpful-responder.support",
+    badgeSlug: "helpful-responder",
+    description: "Antwortet schnell und hilfreich auf Fragen anderer.",
+    defaultReason: "Viele hilfreiche Antworten mit positiver Resonanz.",
+    priority: 110,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const stats = candidate.stats;
+          if (!stats) return false;
+          return stats.posts >= 50 && stats.likesReceived >= 100;
+        },
+        {
+          reason: "Mindestens 50 Antworten und über 100 Likes erhalten.",
+        }
+      ),
+  },
+  {
+    id: "mentor.trust",
+    badgeSlug: "mentor",
+    description: "Unterstützt neue Mitglieder nachhaltig.",
+    defaultReason: "Hohe Vertrauensstufe und aktive Hilfestellung.",
+    priority: 120,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const stats = candidate.stats;
+          if (!stats) return false;
+          return hasMinimumTrust(candidate, TrustLevel.VETERAN) && stats.likesGiven >= 120;
+        },
+        {
+          reason: "Vertrauensstufe VETERAN und mindestens 120 gegebene Likes.",
+        }
+      ),
+  },
+  {
+    id: "creative-mind.profile",
+    badgeSlug: "creative-mind",
+    description: "Inspiriert mit Projekten und kreativen Profilinhalten.",
+    defaultReason: "Ausführliches Profil mit mehreren Projektreferenzen.",
+    priority: 130,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const profile = candidate.profile;
+          if (!profile) return false;
+          return (
+            profile.linksCount >= 3 ||
+            profile.socialsCount >= 3 ||
+            profile.aboutLength >= 200 ||
+            profile.interestsLength >= 120
+          );
+        },
+        {
+          reason: "Profil mit mindestens drei Projekten oder umfangreichen Beschreibungen.",
+        }
+      ),
+  },
+  {
+    id: "community-builder.network",
+    badgeSlug: "community-builder",
+    description: "Bringt Menschen zusammen und startet Projekte.",
+    defaultReason: "Hohe Themenanzahl und aktive Community-Verknüpfung.",
+    priority: 140,
+    evaluate: async (context) =>
+      makeGrants(
+        context,
+        (candidate) => {
+          const stats = candidate.stats;
+          if (!stats) return false;
+          return stats.topics >= 30 && stats.posts >= 150 && candidate.followerCount >= 10;
+        },
+        {
+          reason: "Mindestens 30 Themen, 150 Beiträge und 10 Follower.",
+        }
+      ),
+  },
+];
+
+const baseSlugSet = new Set(primaryRules.map((rule) => rule.badgeSlug));
+
+const legacyFallbackRules: BadgeRule[] = Array.from(KNOWN_OFFICIAL_BADGES)
+  .filter((slug) => slug)
+  .map((slug) => ({
+    id: `legacy.profile.${slug}`,
+    badgeSlug: slug,
+    description: `Legacy-Fallback für ${slug}.`,
+    defaultReason: `Legacy-Badge aus importierten Profildaten (${slug}).`,
+    priority: 400,
+    allowRevocation: false,
+    evaluate: async (context) => {
+      const grants: BadgeGrant[] = [];
+      for (const candidate of context.candidates) {
+        if (!withTarget(context, candidate)) continue;
+        const legacy = candidate.profile?.legacyOfficial;
+        const metadata = legacy?.get(slug);
+        if (!metadata) continue;
+        grants.push({
+          userId: candidate.id,
+          reason:
+            metadata.description ??
+            metadata.label ??
+            `Legacy-Badge aus importierten Profildaten (${slug}).`,
+          note: metadata.label ?? null,
+          earnedAt: candidate.createdAt,
+        });
+      }
+      return grants;
+    },
+  }));
+
+const badgeRules: BadgeRule[] = [
+  ...primaryRules,
+  ...legacyFallbackRules.filter((rule) => !baseSlugSet.has(rule.badgeSlug)),
+];
+
+export default badgeRules;

--- a/apps/api/src/badges/types.ts
+++ b/apps/api/src/badges/types.ts
@@ -1,0 +1,98 @@
+import type { PrismaClient, Role, TrustLevel, ConnectedProvider } from "@prisma/client";
+import type { LegacyBadgeMetadata } from "../profile/badges";
+
+export interface CandidateStats {
+  topics: number;
+  posts: number;
+  likesGiven: number;
+  likesReceived: number;
+  reputation: number;
+  trustLevel: TrustLevel;
+  streakDays: number;
+  longestStreak: number;
+  lastActiveAt: Date | null;
+}
+
+export interface CandidateProfileDetails {
+  hasDisplayName: boolean;
+  hasBio: boolean;
+  aboutLength: number;
+  socialsCount: number;
+  linksCount: number;
+  interestsLength: number;
+  legacyOfficial: Map<string, LegacyBadgeMetadata>;
+}
+
+export interface CandidateConnectedAccount {
+  provider: ConnectedProvider;
+  verified: boolean;
+}
+
+export interface BadgeCandidate {
+  id: string;
+  username: string;
+  createdAt: Date;
+  role: Role;
+  stats: CandidateStats | null;
+  profile: CandidateProfileDetails | null;
+  connectedAccounts: CandidateConnectedAccount[];
+  followerCount: number;
+  followingCount: number;
+}
+
+export interface BadgeGrant {
+  userId: string;
+  earnedAt?: Date;
+  note?: string | null;
+  reason?: string | null;
+  seasonKey?: string | null;
+}
+
+export interface BadgeAssignmentResult {
+  userId: string;
+  badgeSlug: string;
+  seasonKey: string | null;
+  earnedAt: Date;
+  note: string | null;
+  earnedReason: string | null;
+  priority: number;
+  allowRevocation: boolean;
+  ruleId: string;
+}
+
+export interface BadgeRule {
+  /**
+   * Stable identifier for logging and tests.
+   */
+  id: string;
+  badgeSlug: string;
+  description: string;
+  defaultReason?: string;
+  seasonKey?: string | null;
+  priority?: number;
+  allowRevocation?: boolean;
+  evaluate(context: BadgeEvaluationContext): Promise<BadgeGrant[] | BadgeGrant[]>;
+}
+
+export interface BadgeEvaluationContext {
+  prisma: PrismaClient;
+  candidates: BadgeCandidate[];
+  now: Date;
+  targetUserIds: Set<string> | null;
+  cache: Map<string, unknown>;
+  useCache<T>(key: string, loader: () => Promise<T>): Promise<T>;
+}
+
+export type BadgeAssignmentSummary = {
+  slug: string;
+  userId: string;
+  seasonKey: string | null;
+  change: "created" | "updated" | "restored" | "noop";
+};
+
+export type BadgeRevocationSummary = {
+  userId: string;
+  badgeSlug: string;
+  seasonKey: string | null;
+  userBadgeId: string;
+};

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import dbPlugin from "./plugins/db";
 import authRoutes from "./routes/auth";
 import usersRoutes from "./routes/users";
 import { errorHandler } from "./errors";
+import internalBadgeRoutes from "./routes/internal/badges";
 
 const main = async () => {
   const app = Fastify({ logger: true });
@@ -31,6 +32,7 @@ const main = async () => {
 
   await app.register(authRoutes, { prefix: "/auth" });
   await app.register(usersRoutes, { prefix: "/users" });
+  await app.register(internalBadgeRoutes, { prefix: "/internal/badges" });
 
   app.setErrorHandler(errorHandler);
 

--- a/apps/api/src/profile/badges.ts
+++ b/apps/api/src/profile/badges.ts
@@ -1,0 +1,125 @@
+import { Prisma } from "@prisma/client";
+import { parseJsonArray } from "../utils/json";
+
+export const KNOWN_OFFICIAL_BADGES = new Set(
+  [
+    "core-team",
+    "operations-lead",
+    "founder",
+    "early-adopter",
+    "verified",
+    "community-champion",
+    "top-poster",
+    "knowledge-sharer",
+    "event-champion",
+    "bug-hunter",
+    "helpful-responder",
+    "mentor",
+    "creative-mind",
+    "community-builder",
+  ].map((slug) => slug.toLowerCase())
+);
+
+export type LegacyBadgeMetadata = { label?: string; description?: string };
+
+export type ParsedCustomBadge = {
+  link: {
+    id: string;
+    label?: string;
+    url: string;
+    handle?: string | null;
+    icon?: string | null;
+  };
+  slugHint: string | null;
+};
+
+export const extractProfileBadges = (
+  value: Prisma.JsonValue | null | undefined
+): { legacyOfficial: Map<string, LegacyBadgeMetadata>; custom: ParsedCustomBadge[] } => {
+  const entries = parseJsonArray<unknown>(value);
+  const legacyOfficial = new Map<string, LegacyBadgeMetadata>();
+  const custom: ParsedCustomBadge[] = [];
+
+  entries.forEach((entry, index) => {
+    if (typeof entry === "string") {
+      const slug = entry.trim().toLowerCase();
+      if (slug) {
+        legacyOfficial.set(slug, {});
+      }
+      return;
+    }
+
+    if (entry && typeof entry === "object") {
+      const record = entry as Record<string, unknown>;
+      const slugValue =
+        typeof record.slug === "string"
+          ? record.slug
+          : typeof record.id === "string"
+          ? record.id
+          : undefined;
+      const normalizedSlug = slugValue?.trim().toLowerCase() ?? null;
+      const label = typeof record.label === "string" ? record.label : undefined;
+      const description =
+        typeof record.description === "string" ? record.description : undefined;
+      const url = typeof record.url === "string" ? record.url : undefined;
+      const handle =
+        typeof record.handle === "string"
+          ? record.handle
+          : record.handle === null
+          ? null
+          : undefined;
+      const icon =
+        typeof record.icon === "string"
+          ? record.icon
+          : record.icon === null
+          ? null
+          : undefined;
+      const type = typeof record.type === "string" ? record.type.toLowerCase() : undefined;
+      const kind = typeof record.kind === "string" ? record.kind.toLowerCase() : undefined;
+      const category =
+        typeof record.category === "string" ? record.category.toLowerCase() : undefined;
+
+      if (normalizedSlug) {
+        const flaggedOfficial =
+          KNOWN_OFFICIAL_BADGES.has(normalizedSlug) ||
+          type === "official" ||
+          kind === "official" ||
+          category === "official" ||
+          type === "team" ||
+          kind === "team" ||
+          category === "team";
+
+        if (flaggedOfficial) {
+          legacyOfficial.set(normalizedSlug, { label, description });
+          return;
+        }
+      }
+
+      if (url) {
+        const id =
+          (typeof record.id === "string" && record.id.trim()) ||
+          normalizedSlug ||
+          `legacy-${index}`;
+        custom.push({
+          link: {
+            id,
+            label,
+            url,
+            handle: handle ?? null,
+            icon: icon ?? null,
+          },
+          slugHint: normalizedSlug,
+        });
+      }
+    }
+  });
+
+  return { legacyOfficial, custom };
+};
+
+export const formatBadgeName = (slug: string) =>
+  slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");

--- a/apps/api/src/routes/internal/badges.ts
+++ b/apps/api/src/routes/internal/badges.ts
@@ -1,0 +1,39 @@
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import { createRequireAuth } from "../../middlewares/requireAuth";
+import { BadgeAssignmentOrchestrator } from "../../badges/assignment";
+
+const recomputeSchema = z.object({
+  userId: z.string().cuid().optional(),
+  userIds: z.array(z.string().cuid()).optional(),
+  dryRun: z.boolean().optional(),
+  all: z.boolean().optional(),
+});
+
+const internalBadgeRoutes: FastifyPluginAsync = async (app) => {
+  const requireAuth = createRequireAuth(app);
+
+  app.post(
+    "/recompute",
+    { preHandler: requireAuth },
+    async (request, reply) => {
+      const payload = recomputeSchema.parse(request.body ?? {});
+
+      if (request.user?.role !== "ADMIN") {
+        return reply.code(403).send({ error: "FORBIDDEN" });
+      }
+
+      const orchestrator = new BadgeAssignmentOrchestrator(app.db);
+      const result = await orchestrator.recompute({
+        userIds: payload.all
+          ? undefined
+          : payload.userIds ?? (payload.userId ? [payload.userId] : undefined),
+        dryRun: payload.dryRun ?? false,
+      });
+
+      return reply.send(result);
+    }
+  );
+};
+
+export default internalBadgeRoutes;

--- a/apps/api/src/utils/json.ts
+++ b/apps/api/src/utils/json.ts
@@ -1,0 +1,25 @@
+import { Prisma } from "@prisma/client";
+
+export const parseJsonArray = <T>(value: Prisma.JsonValue | null | undefined): T[] => {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value as T[];
+  }
+  return [];
+};
+
+export const parseJsonObject = <T extends Record<string, unknown>>(
+  value: Prisma.JsonValue | null | undefined
+): T | null => {
+  if (!value) return null;
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as T;
+  }
+  return null;
+};
+
+export const toJsonInput = (value: unknown) => {
+  if (value === undefined) return undefined;
+  if (value === null) return Prisma.JsonNull;
+  return value as Prisma.InputJsonValue;
+};

--- a/apps/api/test/badges/evaluator.test.ts
+++ b/apps/api/test/badges/evaluator.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { runBadgeRules } from "../../src/badges/evaluator";
+import badgeRules from "../../src/badges/rules";
+import type { BadgeCandidate, BadgeEvaluationContext } from "../../src/badges/types";
+import { BadgeAssignmentOrchestrator } from "../../src/badges/assignment";
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+const basePrismaMock = {
+  user: {
+    findMany: async () => [],
+  },
+  badge: {
+    findMany: async () => [],
+  },
+  userBadge: {
+    findMany: async () => [],
+    upsert: async () => ({}),
+    update: async () => ({}),
+  },
+  $transaction: async (operations: Promise<unknown>[]) => {
+    for (const op of operations) await op;
+    return [];
+  },
+} as unknown as PrismaClient;
+
+const createContext = (candidates: BadgeCandidate[], overrides?: Partial<BadgeEvaluationContext>) => {
+  const cache = overrides?.cache ?? new Map<string, unknown>();
+  const context: BadgeEvaluationContext = {
+    prisma: overrides?.prisma ?? basePrismaMock,
+    candidates,
+    now: overrides?.now ?? new Date("2024-01-01T00:00:00.000Z"),
+    targetUserIds: overrides?.targetUserIds ?? null,
+    cache,
+    async useCache<T>(key: string, loader: () => Promise<T>): Promise<T> {
+      if (cache.has(key)) {
+        return cache.get(key) as T;
+      }
+      const value = await loader();
+      cache.set(key, value);
+      return value;
+    },
+  };
+  return context;
+};
+
+describe("badge rules", () => {
+  it("assigns core-team and operations-lead to administrators", async () => {
+    const candidate: BadgeCandidate = {
+      id: "admin-1",
+      username: "admin",
+      createdAt: new Date("2023-01-01T00:00:00.000Z"),
+      role: "ADMIN",
+      stats: {
+        topics: 10,
+        posts: 50,
+        likesGiven: 120,
+        likesReceived: 300,
+        reputation: 600,
+        trustLevel: "ADMINISTRATOR",
+        streakDays: 5,
+        longestStreak: 5,
+        lastActiveAt: new Date("2024-01-01T00:00:00.000Z"),
+      },
+      profile: {
+        hasDisplayName: true,
+        hasBio: true,
+        aboutLength: 120,
+        socialsCount: 2,
+        linksCount: 1,
+        interestsLength: 80,
+        legacyOfficial: new Map(),
+      },
+      connectedAccounts: [],
+      followerCount: 3,
+      followingCount: 1,
+    };
+
+    const context = createContext([candidate]);
+    const assignments = await runBadgeRules(badgeRules, context);
+    const slugs = assignments.map((assignment) => assignment.badgeSlug);
+
+    expect(slugs).toContain("core-team");
+    expect(slugs).toContain("operations-lead");
+  });
+
+  it("marks early adopters via cached first-100 set", async () => {
+    const candidate: BadgeCandidate = {
+      id: "member-1",
+      username: "fan",
+      createdAt: new Date("2023-02-01T00:00:00.000Z"),
+      role: "MEMBER",
+      stats: {
+        topics: 2,
+        posts: 3,
+        likesGiven: 1,
+        likesReceived: 5,
+        reputation: 5,
+        trustLevel: "MEMBER",
+        streakDays: 0,
+        longestStreak: 0,
+        lastActiveAt: null,
+      },
+      profile: {
+        hasDisplayName: false,
+        hasBio: false,
+        aboutLength: 0,
+        socialsCount: 0,
+        linksCount: 0,
+        interestsLength: 0,
+        legacyOfficial: new Map(),
+      },
+      connectedAccounts: [],
+      followerCount: 0,
+      followingCount: 0,
+    };
+
+    const cache = new Map<string, unknown>();
+    cache.set("badges:early:set", new Set([candidate.id]));
+    cache.set("badges:founder:set", new Set<string>());
+
+    const context = createContext([candidate], { cache });
+    const assignments = await runBadgeRules(badgeRules, context);
+    const slugs = assignments.map((assignment) => assignment.badgeSlug);
+
+    expect(slugs).toContain("early-adopter");
+    expect(slugs).not.toContain("founder");
+  });
+});
+
+class MockPrisma {
+  public readonly user: PrismaClient["user"];
+  public readonly badge: PrismaClient["badge"];
+  public readonly userBadge: PrismaClient["userBadge"];
+  public readonly $transaction: PrismaClient["$transaction"];
+  public readonly creates: Prisma.UserBadgeCreateArgs[] = [];
+  public readonly upserts: Prisma.UserBadgeUpsertArgs[] = [];
+  public readonly updates: Prisma.UserBadgeUpdateArgs[] = [];
+
+  private readonly users: any[];
+  private readonly badges: any[];
+  private readonly userBadges: any[];
+
+  constructor(data: { users: any[]; badges: any[]; userBadges: any[] }) {
+    this.users = data.users;
+    this.badges = data.badges;
+    this.userBadges = data.userBadges;
+
+    this.user = {
+      findMany: async (args?: any) => {
+        let records = [...this.users];
+        if (args?.where?.id?.in) {
+          const ids: string[] = args.where.id.in;
+          records = records.filter((record) => ids.includes(record.id));
+        }
+        if (args?.orderBy?.createdAt === "asc") {
+          records = records.sort(
+            (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+          );
+        }
+        if (typeof args?.take === "number") {
+          records = records.slice(0, args.take);
+        }
+        return records;
+      },
+    } as unknown as PrismaClient["user"];
+
+    this.badge = {
+      findMany: async () => this.badges,
+    } as unknown as PrismaClient["badge"];
+
+    this.userBadge = {
+      findMany: async (args?: any) => {
+        let records = [...this.userBadges];
+        if (args?.where?.userId?.in) {
+          const ids: string[] = args.where.userId.in;
+          records = records.filter((record) => ids.includes(record.userId));
+        }
+        return records;
+      },
+      create: async (args: Prisma.UserBadgeCreateArgs) => {
+        this.creates.push(args);
+        return {};
+      },
+      upsert: async (args: Prisma.UserBadgeUpsertArgs) => {
+        this.upserts.push(args);
+        return {};
+      },
+      update: async (args: Prisma.UserBadgeUpdateArgs) => {
+        this.updates.push(args);
+        return {};
+      },
+    } as unknown as PrismaClient["userBadge"];
+
+    this.$transaction = (async (arg: any) => {
+      if (Array.isArray(arg)) {
+        for (const operation of arg) {
+          await operation;
+        }
+        return [] as never[];
+      }
+      if (typeof arg === "function") {
+        return arg(this as unknown as PrismaClient);
+      }
+      return [] as never[];
+    }) as unknown as PrismaClient["$transaction"];
+  }
+}
+
+describe("badge assignment orchestrator", () => {
+  let prisma: MockPrisma;
+
+  beforeEach(() => {
+    prisma = new MockPrisma({
+      users: [
+        {
+          id: "u1",
+          username: "hero",
+          createdAt: new Date("2023-01-01T00:00:00.000Z"),
+          role: "MEMBER",
+          displayName: "Hero",
+          bio: "",
+          stats: {
+            topics: 35,
+            posts: 210,
+            likesGiven: 220,
+            likesReceived: 260,
+            reputation: 480,
+            trustLevel: "VETERAN",
+            streakDays: 15,
+            longestStreak: 15,
+            lastActiveAt: new Date("2024-01-01T00:00:00.000Z"),
+          },
+          profile: {
+            about: "Working on community projects",
+            interests: "community",
+            socials: [],
+            links: [],
+            badges: null,
+            bio: null,
+          },
+          connectedAccounts: [
+            { provider: "GITHUB", verified: true },
+          ],
+          _count: { followers: 12, following: 5 },
+        },
+        {
+          id: "u2",
+          username: "lurker",
+          createdAt: new Date("2023-05-01T00:00:00.000Z"),
+          role: "MEMBER",
+          displayName: null,
+          bio: null,
+          stats: {
+            topics: 1,
+            posts: 2,
+            likesGiven: 0,
+            likesReceived: 0,
+            reputation: 5,
+            trustLevel: "MEMBER",
+            streakDays: 0,
+            longestStreak: 0,
+            lastActiveAt: null,
+          },
+          profile: {
+            about: "",
+            interests: "",
+            socials: [],
+            links: [],
+            badges: null,
+            bio: null,
+          },
+          connectedAccounts: [],
+          _count: { followers: 0, following: 0 },
+        },
+      ],
+      badges: [
+        { id: "b1", slug: "top-poster" },
+        { id: "b1a", slug: "founder" },
+        { id: "b1b", slug: "early-adopter" },
+        { id: "b1c", slug: "verified" },
+        { id: "b2", slug: "community-champion" },
+        { id: "b3", slug: "knowledge-sharer" },
+        { id: "b4", slug: "bug-hunter" },
+        { id: "b5", slug: "helpful-responder" },
+        { id: "b6", slug: "mentor" },
+        { id: "b7", slug: "community-builder" },
+        { id: "b8", slug: "event-champion" },
+      ],
+      userBadges: [
+        {
+          id: "award-1",
+          userId: "u1",
+          badgeId: "b1",
+          badge: { slug: "top-poster" },
+          earnedAt: new Date("2023-06-01T00:00:00.000Z"),
+          seasonKey: null,
+          note: null,
+          earnedReason: null,
+          revokedAt: null,
+        },
+        {
+          id: "award-2",
+          userId: "u2",
+          badgeId: "b1",
+          badge: { slug: "top-poster" },
+          earnedAt: new Date("2023-07-01T00:00:00.000Z"),
+          seasonKey: null,
+          note: null,
+          earnedReason: null,
+          revokedAt: null,
+        },
+      ],
+    });
+  });
+
+  it("creates updates and revocations in a single recompute run", async () => {
+    const orchestrator = new BadgeAssignmentOrchestrator(prisma as unknown as PrismaClient);
+    const result = await orchestrator.recompute({ userIds: ["u1", "u2"], now: new Date("2024-02-01T00:00:00.000Z") });
+
+    expect(result.summaries.length).toBeGreaterThan(0);
+    const revoked = result.revocations.find((entry) => entry.userId === "u2");
+    expect(revoked).toBeTruthy();
+
+    const summarySlugs = result.summaries.map((entry) => entry.slug);
+    expect(prisma.creates.length).toBeGreaterThan(0);
+    expect(prisma.updates.length).toBeGreaterThan(0);
+    expect(summarySlugs).toContain("top-poster");
+  });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"],
     "resolveJsonModule": true
   },
-  "include": ["src", "src/types/**/*.d.ts"]
+  "include": ["src", "src/types/**/*.d.ts", "test"]
 }

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    watch: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.17)
 
   apps/web:
     dependencies:
@@ -657,6 +660,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1235,6 +1242,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.27.8':
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -1473,6 +1483,21 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@1.6.1':
+    resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
+
+  '@vitest/runner@1.6.1':
+    resolution: {integrity: sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==}
+
+  '@vitest/snapshot@1.6.1':
+    resolution: {integrity: sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==}
+
+  '@vitest/spy@1.6.1':
+    resolution: {integrity: sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==}
+
+  '@vitest/utils@1.6.1':
+    resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -1480,6 +1505,10 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -1519,6 +1548,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -1579,6 +1612,9 @@ packages:
 
   asn1.js@5.4.1:
     resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
+  assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1645,6 +1681,10 @@ packages:
       magicast:
         optional: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1671,6 +1711,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@4.5.0:
+    resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1686,6 +1730,9 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -1721,6 +1768,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
@@ -1776,6 +1826,10 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1809,6 +1863,10 @@ packages:
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1956,9 +2014,16 @@ packages:
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
@@ -2099,6 +2164,9 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2110,6 +2178,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -2199,6 +2271,10 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2334,6 +2410,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
     engines: {node: '>= 0.4'}
@@ -2381,6 +2461,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -2432,6 +2515,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  local-pkg@0.5.1:
+    resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2446,6 +2533,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2456,6 +2546,9 @@ packages:
     resolution: {integrity: sha512-0cKdqmilHXWUwWAWnf6CrrjHD8YaqPMtLrmEHXolZusNTr9epULCsiJwIOHk2q1yFxdEwd96D4zShlAj67UJdA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
+  magic-string@0.30.19:
+    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2484,6 +2577,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2556,6 +2652,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -2569,6 +2669,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   mnemonist@0.39.6:
     resolution: {integrity: sha512-A/0v5Z59y63US00cRSLiloEIw3t5G+MiKz4BhX21FI+YBJXBOGW0ohFxTxO08dsOYlzxo87T7vGfZKYp2bcAWA==}
@@ -2613,6 +2716,10 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   nypm@0.6.2:
     resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
@@ -2664,6 +2771,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2675,6 +2786,10 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -2702,6 +2817,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -2713,8 +2832,14 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -2743,6 +2868,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -2801,6 +2929,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prisma@6.16.2:
     resolution: {integrity: sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==}
     engines: {node: '>=18.18'}
@@ -2850,6 +2982,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-markdown@9.1.0:
     resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
@@ -3060,6 +3195,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3087,6 +3225,12 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   steed@1.1.3:
     resolution: {integrity: sha512-EUkci0FAUiE4IvGTSKcDJIQ/eRUP2JJb56+fvZ4sdnguLTqIdKjSxUe138poW8mkvKWXW2sFPrgTsxqoISnmoA==}
@@ -3133,9 +3277,16 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@2.1.1:
+    resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -3182,8 +3333,19 @@ packages:
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3220,6 +3382,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
+
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
@@ -3244,6 +3410,9 @@ packages:
     resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -3313,6 +3482,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@1.6.1:
+    resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite@5.4.20:
     resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -3344,6 +3518,31 @@ packages:
       terser:
         optional: true
 
+  vitest@1.6.1:
+    resolution: {integrity: sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.1
+      '@vitest/ui': 1.6.1
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3363,6 +3562,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3395,6 +3599,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3784,6 +3992,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.8
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4318,6 +4530,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.52.3':
     optional: true
 
+  '@sinclair/typebox@0.27.8': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@tsparticles/basic@3.9.1':
@@ -4659,9 +4873,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@1.6.1':
+    dependencies:
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      chai: 4.5.0
+
+  '@vitest/runner@1.6.1':
+    dependencies:
+      '@vitest/utils': 1.6.1
+      p-limit: 5.0.0
+      pathe: 1.1.2
+
+  '@vitest/snapshot@1.6.1':
+    dependencies:
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+
+  '@vitest/spy@1.6.1':
+    dependencies:
+      tinyspy: 2.2.1
+
+  '@vitest/utils@1.6.1':
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+
   abstract-logging@2.0.1: {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
 
@@ -4696,6 +4943,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -4786,6 +5035,8 @@ snapshots:
       minimalistic-assert: 1.0.1
       safer-buffer: 2.1.2
 
+  assertion-error@1.1.0: {}
+
   async-function@1.0.0: {}
 
   atomic-sleep@1.0.0: {}
@@ -4857,6 +5108,8 @@ snapshots:
       pkg-types: 2.3.0
       rc9: 2.1.2
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4882,6 +5135,16 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@4.5.0:
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.1.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4894,6 +5157,10 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@1.0.3:
+    dependencies:
+      get-func-name: 2.0.2
 
   chokidar@3.6.0:
     dependencies:
@@ -4932,6 +5199,8 @@ snapshots:
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
 
   confbox@0.2.2: {}
 
@@ -4979,6 +5248,10 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@4.1.4:
+    dependencies:
+      type-detect: 4.1.0
+
   deep-is@0.1.4: {}
 
   deepmerge-ts@7.1.5: {}
@@ -5008,6 +5281,8 @@ snapshots:
       dequal: 2.0.3
 
   didyoumean@1.2.2: {}
+
+  diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -5308,7 +5583,23 @@ snapshots:
 
   estree-util-is-identifier-name@3.0.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  execa@8.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
 
   exsolve@1.0.7: {}
 
@@ -5470,6 +5761,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-func-name@2.0.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5489,6 +5782,8 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -5608,6 +5903,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   html-url-attributes@3.0.1: {}
+
+  human-signals@5.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -5737,6 +6034,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@3.0.0: {}
+
   is-string@1.1.1:
     dependencies:
       call-bound: 1.0.4
@@ -5788,6 +6087,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -5834,6 +6135,11 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  local-pkg@0.5.1:
+    dependencies:
+      mlly: 1.8.0
+      pkg-types: 1.3.1
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5846,6 +6152,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@2.3.7:
+    dependencies:
+      get-func-name: 2.0.2
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -5855,6 +6165,10 @@ snapshots:
   lucide-react@0.372.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  magic-string@0.30.19:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -5946,6 +6260,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -6087,6 +6403,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mimic-fn@4.0.0: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimatch@3.1.2:
@@ -6098,6 +6416,13 @@ snapshots:
       brace-expansion: 2.0.2
 
   minipass@7.1.2: {}
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
 
   mnemonist@0.39.6:
     dependencies:
@@ -6128,6 +6453,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  npm-run-path@5.3.0:
+    dependencies:
+      path-key: 4.0.0
 
   nypm@0.6.2:
     dependencies:
@@ -6185,6 +6514,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@6.0.0:
+    dependencies:
+      mimic-fn: 4.0.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -6203,6 +6536,10 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-limit@5.0.0:
+    dependencies:
+      yocto-queue: 1.2.1
 
   p-locate@5.0.0:
     dependencies:
@@ -6230,6 +6567,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-key@4.0.0: {}
+
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -6239,7 +6578,11 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@1.1.1: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -6270,6 +6613,12 @@ snapshots:
       thread-stream: 3.1.0
 
   pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
 
   pkg-types@2.3.0:
     dependencies:
@@ -6320,6 +6669,12 @@ snapshots:
 
   prettier@3.6.2: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   prisma@6.16.2(typescript@5.9.2):
     dependencies:
       '@prisma/config': 6.16.2
@@ -6366,6 +6721,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-markdown@9.1.0(@types/react@18.3.24)(react@18.3.1):
     dependencies:
@@ -6636,6 +6993,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
@@ -6654,6 +7013,10 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   steed@1.1.3:
     dependencies:
@@ -6737,7 +7100,13 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-final-newline@3.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  strip-literal@2.1.1:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-js@1.1.17:
     dependencies:
@@ -6810,7 +7179,13 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.1: {}
+
+  tinypool@0.8.4: {}
+
+  tinyspy@2.2.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6840,6 +7215,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
 
@@ -6877,6 +7254,8 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.2: {}
+
+  ufo@1.6.1: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -6961,6 +7340,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@1.6.1(@types/node@20.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      vite: 5.4.20(@types/node@20.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite@5.4.20(@types/node@20.19.17):
     dependencies:
       esbuild: 0.21.5
@@ -6969,6 +7366,40 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.17
       fsevents: 2.3.3
+
+  vitest@1.6.1(@types/node@20.19.17):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.9.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.20(@types/node@20.19.17)
+      vite-node: 1.6.1(@types/node@20.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7015,6 +7446,11 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
 
   wrap-ansi@7.0.0:
@@ -7038,6 +7474,8 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary
- centralize badge rule definitions and evaluation services for computing user awards
- persist badge upserts and revocations through a transactional orchestrator with a new internal recompute endpoint
- extend the schema, documentation, and Vitest coverage for the automated badge workflow

## Testing
- pnpm --filter nexuslabs-api build
- pnpm --filter nexuslabs-api test

------
https://chatgpt.com/codex/tasks/task_e_68d950be17a88327b97853517239c23c